### PR TITLE
Initial Commit of Utilities

### DIFF
--- a/Tests/BaseDbClassTest.php
+++ b/Tests/BaseDbClassTest.php
@@ -1,0 +1,45 @@
+<?php
+
+	namespace Stoic\Tests\Utilities;
+
+	use PHPUnit\Framework\TestCase;
+	use Stoic\Utilities\BaseDbClass;
+	use Pseudo\Pdo;
+	use Stoic\Log\Logger;
+
+	class BasicBaseClass extends BaseDbClass {
+		public $testing;
+
+
+		public function tryBadQuery() {
+			return $this->tryPdoExcept(function () {
+				throw new \PDOException('This is a test error');
+			}, 'Testing');
+		}
+
+		public function tryNoQuery() {
+			return $this->tryPdoExcept(function () {
+				return true;
+			}, 'Testing');
+		}
+	}
+
+	class BaseDbClassTest extends TestCase {
+		public function test_Init() {
+			$cls = new BasicBaseClass(new Pdo(), new Logger());
+			$cls->testing = 'testing';
+
+			self::assertEquals('testing', $cls->testing);
+
+			return;
+		}
+
+		public function test_TryPdoExcept() {
+			$cls = new BasicBaseClass(new Pdo());
+
+			self::assertTrue($cls->tryNoQuery());
+			self::assertNull($cls->tryBadQuery());
+
+			return;
+		}
+	}

--- a/Tests/BaseDbModelTest.php
+++ b/Tests/BaseDbModelTest.php
@@ -106,7 +106,7 @@
 			}
 
 			try {
-				$stmt = $this->db->prepare("SELECT COUNT(*) FROM `Role` WHERE `Name` = :name");
+				$stmt = $this->db->prepare("SELECT COUNT(*) FROM Role WHERE Name = :name");
 				$stmt->bindValue(':name', $this->name, \PDO::PARAM_STR);
 				$stmt->execute();
 
@@ -149,7 +149,7 @@
 			}
 
 			try {
-				$stmt = $this->db->prepare("SELECT COUNT(*) FROM `Role` WHERE `Name` = :name AND `ID` <> :id");
+				$stmt = $this->db->prepare("SELECT COUNT(*) FROM Role WHERE Name = :name AND ID <> :id");
 				$stmt->bindValue(':name', $this->name, \PDO::PARAM_STR);
 				$stmt->bindValue(':id', $this->id, \PDO::PARAM_INT);
 				$stmt->execute();
@@ -219,8 +219,8 @@
 		public function test_Instantiation() {
 		  $pdo = new Pdo();
 		  $role = new Role($pdo);
-		  $pdo->mock("SELECT `ID`, `Name` FROM `Role` WHERE `ID` = :id", new Result(), array(':id' => 1));
-		  $pdo->mock("SELECT COUNT(*) FROM `Role` WHERE `Name` = :name", array(array('COUNT(*)' => 1)), array(':name' => 'Testing'));
+		  $pdo->mock("SELECT ID, Name FROM Role WHERE ID = :id", new Result(), array(':id' => 1));
+		  $pdo->mock("SELECT COUNT(*) FROM Role WHERE Name = :name", array(array('COUNT(*)' => 1)), array(':name' => 'Testing'));
 
 		  self::assertTrue($role->read()->isBad());
 		  self::assertTrue($role->update()->isBad());
@@ -237,12 +237,12 @@
 		  $readResult = new Result(array(array('ID' => 1, 'Name' => 'Testing')), array(':id' => 1));
 		  $readResult->setAffectedRowCount(1);
 
-		  $pdo->mock("INSERT INTO `Role` (`Name`) VALUES (:name)", $insertResult, array(':name' => 'Testing'));
-		  $pdo->mock("UPDATE `Role` SET `Name` = :name WHERE `ID` = :id", new Result(), array(':name' => 'Testarino', ':id' => 1));
-		  $pdo->mock("SELECT COUNT(*) FROM `Role` WHERE `Name` = :name", array(array('COUNT(*)' => 0)), array(':name' => 'Testing'));
-		  $pdo->mock("SELECT COUNT(*) FROM `Role` WHERE `Name` = :name AND `ID` <> :id", array(array('COUNT(*)' => 0)), array(':name' => 'Testarino', ':id' => 1));
-		  $pdo->mock("SELECT `ID`, `Name` FROM `Role` WHERE `ID` = :id", $readResult, array(':id' => 1));
-		  $pdo->mock("DELETE FROM `Role` WHERE `ID` = :id", new Result(), array(':id' => 1));
+		  $pdo->mock("INSERT INTO Role (Name) VALUES (:name)", $insertResult, array(':name' => 'Testing'));
+		  $pdo->mock("UPDATE Role SET Name = :name WHERE ID = :id", new Result(), array(':name' => 'Testarino', ':id' => 1));
+		  $pdo->mock("SELECT COUNT(*) FROM Role WHERE Name = :name", array(array('COUNT(*)' => 0)), array(':name' => 'Testing'));
+		  $pdo->mock("SELECT COUNT(*) FROM Role WHERE Name = :name AND ID <> :id", array(array('COUNT(*)' => 0)), array(':name' => 'Testarino', ':id' => 1));
+		  $pdo->mock("SELECT ID, Name FROM Role WHERE ID = :id", $readResult, array(':id' => 1));
+		  $pdo->mock("DELETE FROM Role WHERE ID = :id", new Result(), array(':id' => 1));
 
 		  $role = new Role($pdo);
 		  $role = new Role($pdo, new Logger());
@@ -262,7 +262,7 @@
 		  self::assertTrue($role->update()->isBad());
 
 		  $pdo = new Pdo();
-		  $pdo->mock("SELECT COUNT(*) FROM `Role` WHERE `Name` = :name AND `ID` <> :id", array(array('COUNT(*)' => 1)), array(':name' => 'Testing', ':id' => 1));
+		  $pdo->mock("SELECT COUNT(*) FROM Role WHERE Name = :name AND ID <> :id", array(array('COUNT(*)' => 1)), array(':name' => 'Testing', ':id' => 1));
 
 		  $role = new Role($pdo);
 		  $role->id = 1;
@@ -380,7 +380,7 @@
 			$pdo = new Pdo();
 			$result = new Result(array(array('ID' => 1, 'Name' => 'Testing', 'Date' => '2014-10-27 01:20:30', 'Active' => 1, 'IntEnum' => 1, 'StringEnum' => 'VALUE_TWO')), array(':id' => 1));
 			$result->setAffectedRowCount(1);
-			$pdo->mock("SELECT `ID`, `Name`, `Date`, `Active`, `IntEnum`, `StringEnum` FROM `Test` WHERE `ID` = :id", $result, array(':id' => 1));
+			$pdo->mock("SELECT ID, Name, Date, Active, IntEnum, StringEnum FROM Test WHERE ID = :id", $result, array(':id' => 1));
 			$complete = new CompleteDbClass($pdo);
 			$complete->id = 1;
 
@@ -395,7 +395,7 @@
 			$pdo = new Pdo();
 			$insertResult = new Result();
 			$insertResult->setInsertId(1);
-			$pdo->mock("INSERT INTO `Test` (`Name`, `Date`, `Active`, `IntEnum`, `StringEnum`) VALUES (:name, :date, :active, :intEnum, :stringEnum)", $insertResult, array(':name' => 'Testing', ':date' => null, ':active' => 0, ':intEnum' => 2, ':stringEnum' => 'VALUE_ONE'));
+			$pdo->mock("INSERT INTO Test (Name, Date, Active, IntEnum, StringEnum) VALUES (:name, :date, :active, :intEnum, :stringEnum)", $insertResult, array(':name' => 'Testing', ':date' => null, ':active' => 0, ':intEnum' => 2, ':stringEnum' => 'VALUE_ONE'));
 			$complete = new CompleteDbClass($pdo);
 			$complete->id = 1;
 			$complete->name = 'Testing';
@@ -409,7 +409,7 @@
 			$pdo = new Pdo();
 			$insertResult = new Result();
 			$insertResult->setInsertId(1);
-			$pdo->mock("INSERT INTO `Test` (`Name`, `Date`, `Active`, `IntEnum`, `StringEnum`) VALUES (:name, :date, :active, :intEnum, :stringEnum)", $insertResult, array(':name' => 'Testing', ':date' => '2014-10-27 01:20:30', ':active' => 1, ':intEnum' => 2, ':stringEnum' => 'VALUE_ONE'));
+			$pdo->mock("INSERT INTO Test (Name, Date, Active, IntEnum, StringEnum) VALUES (:name, :date, :active, :intEnum, :stringEnum)", $insertResult, array(':name' => 'Testing', ':date' => '2014-10-27 01:20:30', ':active' => 1, ':intEnum' => 2, ':stringEnum' => 'VALUE_ONE'));
 			$complete = new CompleteDbClass($pdo);
 			$complete->id = 1;
 			$complete->name = 'Testing';
@@ -448,14 +448,14 @@
 		public function test_BaseDbModel_QueryGen() {
 			$role = new Role(new Pdo());
 
-			self::assertEquals('INSERT INTO `Role` (`Name`) VALUES (:name)', $role->generateClassQuery(BaseDbQueryTypes::INSERT));
-			self::assertEquals('INSERT INTO `Role` (`Name`) VALUES (:name)', $role->generateClassQuery(BaseDbQueryTypes::INSERT, false));
-			self::assertEquals('SELECT `ID`, `Name` FROM `Role` WHERE `ID` = :id', $role->generateClassQuery(BaseDbQueryTypes::SELECT));
-			self::assertEquals('SELECT `ID`, `Name` FROM `Role`', $role->generateClassQuery(BaseDbQueryTypes::SELECT, false));
-			self::assertEquals('UPDATE `Role` SET `Name` = :name WHERE `ID` = :id', $role->generateClassQuery(BaseDbQueryTypes::UPDATE));
-			self::assertEquals('UPDATE `Role` SET `Name` = :name WHERE `ID` = :id', $role->generateClassQuery(BaseDbQueryTypes::UPDATE, false));
-			self::assertEquals('DELETE FROM `Role` WHERE `ID` = :id', $role->generateClassQuery(BaseDbQueryTypes::DELETE));
-			self::assertEquals('DELETE FROM `Role` WHERE `ID` = :id', $role->generateClassQuery(BaseDbQueryTypes::DELETE, false));
+			self::assertEquals('INSERT INTO Role (Name) VALUES (:name)', $role->generateClassQuery(BaseDbQueryTypes::INSERT));
+			self::assertEquals('INSERT INTO Role (Name) VALUES (:name)', $role->generateClassQuery(BaseDbQueryTypes::INSERT, false));
+			self::assertEquals('SELECT ID, Name FROM Role WHERE ID = :id', $role->generateClassQuery(BaseDbQueryTypes::SELECT));
+			self::assertEquals('SELECT ID, Name FROM Role', $role->generateClassQuery(BaseDbQueryTypes::SELECT, false));
+			self::assertEquals('UPDATE Role SET Name = :name WHERE ID = :id', $role->generateClassQuery(BaseDbQueryTypes::UPDATE));
+			self::assertEquals('UPDATE Role SET Name = :name WHERE ID = :id', $role->generateClassQuery(BaseDbQueryTypes::UPDATE, false));
+			self::assertEquals('DELETE FROM Role WHERE ID = :id', $role->generateClassQuery(BaseDbQueryTypes::DELETE));
+			self::assertEquals('DELETE FROM Role WHERE ID = :id', $role->generateClassQuery(BaseDbQueryTypes::DELETE, false));
 
 			return;
 		}

--- a/Tests/BaseDbModelTest.php
+++ b/Tests/BaseDbModelTest.php
@@ -1,0 +1,462 @@
+<?php
+
+	namespace Stoic\Tests\Utilities;
+
+	use PHPUnit\Framework\TestCase;
+	use Stoic\Utilities\BaseDbModel;
+	use Stoic\Utilities\BaseDbField;
+	use Stoic\Utilities\BaseDbTypes;
+	use Stoic\Utilities\BaseDbQueryTypes;
+	use Stoic\Utilities\ClassPropertyNotFoundException;
+	use Stoic\Utilities\EnumBase;
+	use Stoic\Utilities\ReturnHelper;
+	use Pseudo\Pdo;
+	use Pseudo\Result;
+	use Stoic\Log\Logger;
+
+	class TestEnum extends EnumBase {
+		const VALUE_ONE = 1;
+		const VALUE_TWO = 2;
+	}
+
+	class FromArrayTestClass1 extends BaseDbModel {
+		public $test;
+	}
+
+	class FromArrayTestClass2 extends BaseDbModel {
+		public $test;
+
+
+		protected function __setupModel() {
+			$this->setColumn('test', 'test', BaseDbTypes::INTEGER, true, true, true);
+
+			return;
+		}
+	}
+
+	class BasicTestDbClass extends BaseDbModel {
+		protected $test;
+		protected $test2;
+
+
+		protected function __setupModel() {
+			$this->setTableName('TestTable');
+			$this->setColumn('test', 'test', BaseDbTypes::INTEGER, true, true, true);
+			$this->setColumn('test2', 'test2', BaseDbTypes::STRING, false, true, true, true);
+
+			return;
+		}
+	}
+
+	class BadTestDbClass extends BaseDbModel {
+		protected function __setupModel() {
+			$this->setColumn('test', 'test', BaseDbTypes::INTEGER, false, true, true);
+			$this->setColumn('test', 'test', BaseDbTypes::INTEGER, false, true, true);
+
+			return;
+		}
+	}
+
+	class EmptyDbClass extends BaseDbModel {
+		public $test;
+	}
+
+	class NoInsertUpdateFieldDbClass extends BaseDbModel {
+		public $test;
+
+
+		protected function __setupModel() {
+			$this->setColumn('test', 'test', BaseDbTypes::INTEGER, false, false, false);
+
+			return;
+		}
+	}
+
+	class NoPrimariesDbClass extends BaseDbModel {
+		public $test;
+
+
+		protected function __setupModel() {
+			$this->setColumn('test', 'test', BaseDbTypes::INTEGER, false, true, true);
+
+			return;
+		}
+	}
+
+	class Role extends BaseDbModel {
+		public $id;
+		public $name;
+
+
+		public static function fromId($id, \PDO $db, Logger $log = null) {
+			$ret = new Role($db, $log);
+			$ret->id = intval($id);
+			
+			if ($ret->read()->isBad()) {
+				$ret->id = 0;
+			}
+
+			return $ret;
+		}
+
+
+		protected function __canCreate() {
+			if ($this->id > 0 || empty($this->name) || $this->name === null) {
+				return false;
+			}
+
+			try {
+				$stmt = $this->db->prepare("SELECT COUNT(*) FROM `Role` WHERE `Name` = :name");
+				$stmt->bindValue(':name', $this->name, \PDO::PARAM_STR);
+				$stmt->execute();
+
+				if ($stmt->fetch()['COUNT(*)'] > 0) {
+					return false;
+				}
+			} catch (\PDOException $ex) {
+				$this->log->error("Error checking for duplicates on creation: {ERROR}", array('ERROR' => $ex->getMessage()));
+
+				return false;
+			}
+
+			return true;
+		}
+
+		protected function __canDelete() {
+			if ($this->id < 1) {
+				return false;
+			}
+
+			return true;
+		}
+
+		protected function __canRead() {
+			if ($this->id < 1) {
+				return false;
+			}
+
+			return true;
+		}
+
+		protected function __canUpdate() {
+			$ret = new ReturnHelper();
+			$ret->makeBad();
+
+			if ($this->id < 1 || empty($this->name) || $this->name === null) {
+				$ret->addMessage("Invalid name or identifier for update");
+
+				return $ret;
+			}
+
+			try {
+				$stmt = $this->db->prepare("SELECT COUNT(*) FROM `Role` WHERE `Name` = :name AND `ID` <> :id");
+				$stmt->bindValue(':name', $this->name, \PDO::PARAM_STR);
+				$stmt->bindValue(':id', $this->id, \PDO::PARAM_INT);
+				$stmt->execute();
+
+				if ($stmt->fetch()['COUNT(*)'] > 0) {
+					$ret->addMessage("Found duplicate role with name {$this->name} in database");
+
+					return $ret;
+				}
+			} catch (\PDOException $ex) {
+				$this->log->error("Error checking for duplicates on creation: {ERROR}", array('ERROR' => $ex->getMessage()));
+
+				return $ret;
+			}
+
+			$ret->makeGood();
+
+			return $ret;
+		}
+
+		protected function __setupModel() {
+			$this->setTableName('Role');
+			$this->setColumn('id', 'ID', BaseDbTypes::INTEGER, true, false, false, false, true);
+			$this->setColumn('name', 'Name', BaseDbTypes::STRING, false, true, true);
+
+			$this->id = 0;
+			$this->name = null;
+
+			return;
+		}
+	}
+
+	class CompleteDbClass extends BaseDbModel {
+		protected $id;
+		protected $name;
+		protected $date;
+		protected $active;
+		/**
+		 * Summary of $intEnum
+		 * @var TestEnum
+		 */
+		protected $intEnum;
+		/**
+		 * Summary of $stringEnum
+		 * @var TestEnum
+		 */
+		protected $stringEnum;
+
+
+		protected function __setupModel() {
+			$this->setTableName('Test');
+			$this->setColumn('id', 'ID', BaseDbTypes::INTEGER, true, false, false, false, true);
+			$this->setColumn('name', 'Name', BaseDbTypes::STRING, false, true, true, true);
+			$this->setColumn('date', 'Date', BaseDbTypes::DATETIME, false, true, true);
+			$this->setColumn('active', 'Active', BaseDbTypes::BOOLEAN, false, true, true);
+			$this->setColumn('intEnum', 'IntEnum', BaseDbTypes::INTEGER, false, true, true);
+			$this->setColumn('stringEnum', 'StringEnum', BaseDbTypes::STRING, false, true, true);
+
+			$this->intEnum = new TestEnum(1);
+			$this->stringEnum = TestEnum::fromString('VALUE_TWO');
+
+			return;
+		}
+	}
+
+	class BaseDbModelTest extends TestCase {
+		public function test_Instantiation() {
+		  $pdo = new Pdo();
+		  $role = new Role($pdo);
+		  $pdo->mock("SELECT `ID`, `Name` FROM `Role` WHERE `ID` = :id", new Result(), array(':id' => 1));
+		  $pdo->mock("SELECT COUNT(*) FROM `Role` WHERE `Name` = :name", array(array('COUNT(*)' => 1)), array(':name' => 'Testing'));
+
+		  self::assertTrue($role->read()->isBad());
+		  self::assertTrue($role->update()->isBad());
+		  self::assertTrue($role->delete()->isBad());
+
+		  $role->name = 'Testing';
+		  self::assertTrue($role->create()->isBad());
+
+		  $role = Role::fromId(1, $pdo);
+		  self::assertEquals(0, $role->id);
+
+		  $insertResult = new Result();
+		  $insertResult->setInsertId(1);
+		  $readResult = new Result(array(array('ID' => 1, 'Name' => 'Testing')), array(':id' => 1));
+		  $readResult->setAffectedRowCount(1);
+
+		  $pdo->mock("INSERT INTO `Role` (`Name`) VALUES (:name)", $insertResult, array(':name' => 'Testing'));
+		  $pdo->mock("UPDATE `Role` SET `Name` = :name WHERE `ID` = :id", new Result(), array(':name' => 'Testarino', ':id' => 1));
+		  $pdo->mock("SELECT COUNT(*) FROM `Role` WHERE `Name` = :name", array(array('COUNT(*)' => 0)), array(':name' => 'Testing'));
+		  $pdo->mock("SELECT COUNT(*) FROM `Role` WHERE `Name` = :name AND `ID` <> :id", array(array('COUNT(*)' => 0)), array(':name' => 'Testarino', ':id' => 1));
+		  $pdo->mock("SELECT `ID`, `Name` FROM `Role` WHERE `ID` = :id", $readResult, array(':id' => 1));
+		  $pdo->mock("DELETE FROM `Role` WHERE `ID` = :id", new Result(), array(':id' => 1));
+
+		  $role = new Role($pdo);
+		  $role = new Role($pdo, new Logger());
+
+		  $role->name = "Testing";
+		  self::assertTrue($role->create()->isGood());
+		  self::assertEquals(1, $role->id);
+		  self::assertFalse($role->create()->isGood());
+
+		  $role->name = "Testarino";
+		  self::assertTrue($role->update()->isGood());
+		  self::assertTrue($role->delete()->isGood());
+
+		  self::assertEquals(1, Role::fromId(1, $pdo)->id);
+
+		  $role->name = '';
+		  self::assertTrue($role->update()->isBad());
+
+		  $pdo = new Pdo();
+		  $pdo->mock("SELECT COUNT(*) FROM `Role` WHERE `Name` = :name AND `ID` <> :id", array(array('COUNT(*)' => 1)), array(':name' => 'Testing', ':id' => 1));
+
+		  $role = new Role($pdo);
+		  $role->id = 1;
+		  $role->name = 'Testing';
+		  self::assertTrue($role->update()->isBad());
+
+		  return;
+		}
+
+		public function test_FromArray() {
+			try {
+				new BadTestDbClass(new Pdo());
+				self::assertTrue(false);
+			} catch (\InvalidArgumentException $ex) {
+				self::assertEquals("Cannot overwrite a field that has already been set", $ex->getMessage());
+			}
+
+			try {
+				Role::fromArray(['id' => 1, 'roleName' => 'Testing'], new Pdo());
+				self::assertTrue(false);
+			} catch (ClassPropertyNotFoundException $ex) {
+				self::assertEquals("Couldn't find match for roleName index while populating Stoic\Tests\Utilities\Role", $ex->getMessage());
+			}
+
+			return;
+		}
+
+		public function test_BaseDbTypes() {
+			$type = BaseDbTypes::fromString('INTEGER');
+			self::assertEquals(\PDO::PARAM_INT, $type->getDbType());
+
+			$type = BaseDbTypes::fromString('STRING');
+			self::assertEquals(\PDO::PARAM_STR, $type->getDbType());
+
+			$type = BaseDbTypes::fromString('BOOLEAN');
+			self::assertEquals(\PDO::PARAM_BOOL, $type->getDbType());
+
+			$type = BaseDbTypes::fromString('NILL');
+			self::assertEquals(\PDO::PARAM_NULL, $type->getDbType());
+
+			$type = new BaseDbTypes(-1);
+			self::assertEquals(null, $type->getDbType());
+
+			return;
+		}
+
+		public function test_BaseDbField() {
+			try {
+				new BaseDbField('', BaseDbTypes::INTEGER, false, false, false);
+				self::assertTrue(false);
+			} catch (\InvalidArgumentException $ex) {
+				self::assertEquals("Cannot create a BaseDbField object with no column name", $ex->getMessage());
+			}
+
+			try {
+				new BaseDbField('test', -1, false, false, false);
+				self::assertTrue(false);
+			} catch (\InvalidArgumentException $ex) {
+				self::assertEquals("Cannot create a BaseDbField object with an invalid BaseDbTypes value", $ex->getMessage());
+			}
+
+			return;
+		}
+
+		public function test_BaseDbModel_FromArray() {
+			try {
+				FromArrayTestClass1::fromArray(array(), new Pdo());
+				self::assertTrue(false);
+			} catch (\InvalidArgumentException $ex) {
+				self::assertEquals("Cannot populate Stoic\Tests\Utilities\FromArrayTestClass1 from empty source array", $ex->getMessage());
+			}
+
+			try {
+				FromArrayTestClass1::fromArray(array('test' => 1, 'extra' => 2), new Pdo(), new Logger(), ['className']);
+				self::assertTrue(false);
+			} catch (\InvalidArgumentException $ex) {
+				self::assertEquals("Cannot populate Stoic\Tests\Utilities\FromArrayTestClass1 from array, variable count mismatch (class: 1, source: 2)", $ex->getMessage());
+			}
+
+			$cls = FromArrayTestClass1::fromArray(array('test' => 1), new Pdo());
+			self::assertEquals(1, $cls->test);
+
+			$cls = FromArrayTestClass2::fromArray(array('test' => 1), new Pdo());
+			self::assertEquals(1, $cls->test);
+
+			return;
+		}
+
+		public function test_BaseDbModel_GetterSetter() {
+			$cls = new BasicTestDbClass(new Pdo());
+			$cls->test = 1;
+			$cls->test2 = 'testing';
+			$cls->missing = 2;
+
+			self::assertEquals(1, $cls->test);
+			self::assertEquals('testing', $cls->test2);
+			self::assertNull($cls->missing);
+
+			return;
+		}
+
+		public function test_BaseDbModel_CRUD() {
+			$basic = new EmptyDbClass(new Pdo());
+			self::assertTrue($basic->create()->isBad());
+
+			$noInsert = new NoInsertUpdateFieldDbClass(new Pdo());
+			self::assertTrue($noInsert->create()->isBad());
+			self::assertTrue($noInsert->update()->isBad());
+
+			$noPrimary = new NoPrimariesDbClass(new Pdo());
+			self::assertTrue($noPrimary->read()->isBad());
+			self::assertTrue($noPrimary->update()->isBad());
+			self::assertTrue($noPrimary->delete()->isBad());
+
+			$pdo = new Pdo();
+			$result = new Result(array(array('ID' => 1, 'Name' => 'Testing', 'Date' => '2014-10-27 01:20:30', 'Active' => 1, 'IntEnum' => 1, 'StringEnum' => 'VALUE_TWO')), array(':id' => 1));
+			$result->setAffectedRowCount(1);
+			$pdo->mock("SELECT `ID`, `Name`, `Date`, `Active`, `IntEnum`, `StringEnum` FROM `Test` WHERE `ID` = :id", $result, array(':id' => 1));
+			$complete = new CompleteDbClass($pdo);
+			$complete->id = 1;
+
+			self::assertTrue($complete->read()->isGood());
+			self::assertEquals(1, $complete->id);
+			self::assertEquals('Testing', $complete->name);
+			self::assertEquals('2014-10-27 01:20:30', $complete->date);
+			self::assertTrue($complete->active);
+			self::assertEquals(1, $complete->intEnum->getValue());
+			self::assertEquals('VALUE_TWO', $complete->stringEnum->getName());
+
+			$pdo = new Pdo();
+			$insertResult = new Result();
+			$insertResult->setInsertId(1);
+			$pdo->mock("INSERT INTO `Test` (`Name`, `Date`, `Active`, `IntEnum`, `StringEnum`) VALUES (:name, :date, :active, :intEnum, :stringEnum)", $insertResult, array(':name' => 'Testing', ':date' => null, ':active' => 0, ':intEnum' => 2, ':stringEnum' => 'VALUE_ONE'));
+			$complete = new CompleteDbClass($pdo);
+			$complete->id = 1;
+			$complete->name = 'Testing';
+			$complete->date = null;
+			$complete->active = false;
+			$complete->intEnum = 2;
+			$complete->stringEnum = TestEnum::fromString('VALUE_ONE');
+
+			self::assertTrue($complete->create()->isGood());
+
+			$pdo = new Pdo();
+			$insertResult = new Result();
+			$insertResult->setInsertId(1);
+			$pdo->mock("INSERT INTO `Test` (`Name`, `Date`, `Active`, `IntEnum`, `StringEnum`) VALUES (:name, :date, :active, :intEnum, :stringEnum)", $insertResult, array(':name' => 'Testing', ':date' => '2014-10-27 01:20:30', ':active' => 1, ':intEnum' => 2, ':stringEnum' => 'VALUE_ONE'));
+			$complete = new CompleteDbClass($pdo);
+			$complete->id = 1;
+			$complete->name = 'Testing';
+			$complete->date = '2014-10-27 01:20:30';
+			$complete->active = true;
+			$complete->intEnum = 2;
+			$complete->stringEnum = TestEnum::fromString('VALUE_ONE');
+
+			self::assertTrue($complete->create()->isGood());
+			self::assertEquals(1, $complete->id);
+			self::assertEquals('Testing', $complete->name);
+			self::assertEquals('2014-10-27 01:20:30', $complete->date);
+			self::assertEquals(2, $complete->intEnum->getValue());
+			self::assertEquals('VALUE_ONE', $complete->stringEnum->getName());
+
+			return;
+		}
+
+		public function test_BaseDbModel_Meta() {
+			$role = new Role(new Pdo());
+			$arrVersion = $role->toArray();
+			$dbColumns = $role->getDbColumns();
+
+			self::assertEquals('Role', $role->getShortClassName());
+			self::assertEquals('Stoic\Tests\Utilities\Role', $role->getClassName());
+
+			self::assertEquals(0, $arrVersion['id']);
+			self::assertEquals('', $arrVersion['name']);
+
+			self::assertEquals('ID', $dbColumns['id']->column->data());
+			self::assertEquals('Name', $dbColumns['name']->column->data());
+
+			return;
+		}
+
+		public function test_BaseDbModel_QueryGen() {
+			$role = new Role(new Pdo());
+
+			self::assertEquals('INSERT INTO `Role` (`Name`) VALUES (:name)', $role->generateClassQuery(BaseDbQueryTypes::INSERT));
+			self::assertEquals('INSERT INTO `Role` (`Name`) VALUES (:name)', $role->generateClassQuery(BaseDbQueryTypes::INSERT, false));
+			self::assertEquals('SELECT `ID`, `Name` FROM `Role` WHERE `ID` = :id', $role->generateClassQuery(BaseDbQueryTypes::SELECT));
+			self::assertEquals('SELECT `ID`, `Name` FROM `Role`', $role->generateClassQuery(BaseDbQueryTypes::SELECT, false));
+			self::assertEquals('UPDATE `Role` SET `Name` = :name WHERE `ID` = :id', $role->generateClassQuery(BaseDbQueryTypes::UPDATE));
+			self::assertEquals('UPDATE `Role` SET `Name` = :name WHERE `ID` = :id', $role->generateClassQuery(BaseDbQueryTypes::UPDATE, false));
+			self::assertEquals('DELETE FROM `Role` WHERE `ID` = :id', $role->generateClassQuery(BaseDbQueryTypes::DELETE));
+			self::assertEquals('DELETE FROM `Role` WHERE `ID` = :id', $role->generateClassQuery(BaseDbQueryTypes::DELETE, false));
+
+			return;
+		}
+	}

--- a/Tests/PdoHelperTest.php
+++ b/Tests/PdoHelperTest.php
@@ -77,6 +77,7 @@
 			}
 
 			self::assertTrue((new PdoHelper('sqlite::memory:'))->isActive());
+			self::assertTrue((new PdoHelper('sqlite::memory:'))->getDriver()->getValue() === PdoDrivers::PDO_SQLITE);
 
 			return;
 		}

--- a/Tests/PdoHelperTest.php
+++ b/Tests/PdoHelperTest.php
@@ -1,0 +1,185 @@
+<?php
+
+	namespace Stoic\Tests\Utilities;
+
+	use PHPUnit\Framework\TestCase;
+	use Stoic\Utilities\PdoDrivers;
+	use Stoic\Utilities\PdoHelper;
+	use Stoic\Utilities\PdoQuery;
+	use Stoic\Utilities\PdoError;
+
+	class PdoHelperTestable extends PdoHelper {
+		public static function getStoredQueries() {
+			return static::$storedQueries;
+		}
+	}
+
+	class PdoHelperTest extends TestCase {
+		protected static $hasSqlite = false;
+
+		public static function setUpBeforeClass() {
+			if (array_search('sqlite', \PDO::getAvailableDrivers()) !== false) {
+				static::$hasSqlite = true;
+			}
+
+			return;
+		}
+
+		public function test_Structs() {
+			$query = new PdoQuery('SELECT * FROM User WHERE Email = :email', [[':email', 'andrew.male@grokspark.com', \PDO::PARAM_STR]]);
+			self::assertEquals('{"query":"SELECT * FROM User WHERE Email = :email","arguments":[[":email","andrew.male@grokspark.com",2]]}', json_encode($query));
+
+			$error = new PdoError(new \PDOException('Testing'), $query);
+			$errorJson = json_decode(json_encode($error), true);
+
+			self::assertTrue(array_key_exists('message', $errorJson));
+			self::assertTrue(array_key_exists('stackTrace', $errorJson));
+			self::assertEquals('{"query":"SELECT * FROM User WHERE Email = :email","arguments":[[":email","andrew.male@grokspark.com",2]]}', json_encode($errorJson['query']));
+
+			return;
+		}
+
+		public function test_StoredQueries() {
+			if (!static::$hasSqlite) {
+				self::assertTrue(true);
+
+				return;
+			}
+
+			self::assertFalse(PdoHelperTestable::storeQuery('sql', 'sq_test_1', 'SELECT * FROM User WHERE Email = :email', [':email' => \PDO::PARAM_STR]));
+			self::assertTrue(PdoHelperTestable::storeQuery('sqlite', 'sq_test_1', 'SELECT * FROM User WHERE Email = :email', [':email' => \PDO::PARAM_STR]));
+			self::assertFalse(PdoHelperTestable::storeQuery('sqlite', 'sq_test_1', 'SELECT * FROM User WHERE Email = :email', [':email' => \PDO::PARAM_STR]));
+			self::assertTrue(PdoHelperTestable::storeQuery('sqlite', 'sq_test_2', 'INSERT INTO User (Username, Email) VALUES (:username, :email)', [':username' => \PDO::PARAM_STR, ':email' => \PDO::PARAM_STR]));
+			self::assertTrue(PdoHelperTestable::storeQuery(PdoDrivers::PDO_SQLITE, 'sq_test_3', 'SELECT ID, Username, Email FROM User WHERE Username = :username', [':username' => \PDO::PARAM_STR]));
+
+			PdoHelperTestable::storeQueries('sqlite', [
+				['sq_test_4', 'CREATE TABLE User (ID INTEGER PRIMARY KEY, Username TEXT, Email TEXT)', []],
+				['sq_test_5', 'SELECT Username FROM User', []]
+			]);
+
+			$storedQueries = PdoHelperTestable::getStoredQueries();
+
+			self::assertTrue(array_key_exists('sqlite', $storedQueries));
+			self::assertTrue(array_key_exists('sq_test_1', $storedQueries['sqlite']));
+			self::assertTrue(array_key_exists('sq_test_2', $storedQueries['sqlite']));
+			self::assertTrue(array_key_exists('sq_test_3', $storedQueries['sqlite']));
+			self::assertTrue(array_key_exists('sq_test_4', $storedQueries['sqlite']));
+			self::assertTrue(array_key_exists('sq_test_5', $storedQueries['sqlite']));
+
+			return;
+		}
+
+		public function test_Initialization() {
+			if (!static::$hasSqlite) {
+				self::assertTrue(true);
+
+				return;
+			}
+
+			self::assertTrue((new PdoHelper('sqlite::memory:'))->isActive());
+
+			return;
+		}
+
+		public function test_Transactions() {
+			if (!static::$hasSqlite) {
+				self::assertTrue(true);
+
+				return;
+			}
+
+			try {
+				$db = new PdoHelper('sqlite::memory:');
+				$db->beginTransaction();
+				$db->execStored('sq_test_4');
+				self::assertTrue($db->inTransaction());
+				$db->rollback();
+				$db->beginTransaction();
+				$db->execStored('sq_test_4');
+				$db->commit();
+
+				self::assertTrue(true);
+			} catch (\PDOException $ex) {
+				self::assertFalse(true);
+			}
+
+			return;
+		}
+
+		public function test_Errors() {
+			if (!static::$hasSqlite) {
+				self::assertTrue(true);
+
+				return;
+			}
+
+			$db = new PdoHelper('sqlite::memory:');
+			$db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+			self::assertEquals(\PDO::ERRMODE_EXCEPTION, $db->getAttribute(\PDO::ATTR_ERRMODE));
+
+			try {
+				$db->execStored('sq_test_4');
+				$db->execStored('sq_test_4');
+
+				self::assertTrue(false);
+			} catch (\PDOException $ex) {
+				self::assertEquals('SQLSTATE[HY000]: General error: 1 table User already exists', $ex->getMessage());
+				self::assertEquals('HY000', $db->errorCode());
+				self::assertEquals('["HY000",1,"table User already exists"]', json_encode($db->errorInfo()));
+				self::assertEquals(1, count($db->getErrors()));
+				self::assertEquals(1, count($db->getQueries()));
+				self::assertEquals(1, $db->getQueryCount());
+			}
+
+			self::assertEquals(0, $db->execStored('sq_test_5'));
+
+			return;
+		}
+
+		public function test_Queries() {
+			if (!static::$hasSqlite) {
+				self::assertTrue(true);
+
+				return;
+			}
+
+			$db = new PdoHelper('sqlite::memory:');
+			$db->setAttributes();
+			$db->setAttributes([\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+
+			try {
+				$db->execStored('sq_test_4');
+				self::assertEquals(0, $db->execStored('sq_test_-1'));
+
+				$stmt = $db->prepareStored('sq_test_2', [':username' => 'AndyM84', ':email' => 'andrew.male@grokspark.com']);
+				$stmt->execute();
+
+				self::assertEquals('1', $db->lastInsertId());
+				self::assertNull($db->prepareStored('sq_test_2', [':username' => 'AndyM84']));
+				self::assertNull($db->prepareStored('sq_test_2', [':username' => 'AndyM84', ':emailAddress' => 'andrew.male@grokspark.com']));
+
+				foreach ($db->queryStored('sq_test_5') as $row) {
+					self::assertEquals('AndyM84', $row['Username']);
+				}
+
+				self::assertNull($db->queryStored('sq_test_-1'));
+
+				self::assertEquals("'Testing''s'", $db->quote("Testing's"));
+				self::assertEquals("'Testing''s'", $db->quote("Testing's", \PDO::PARAM_STR));
+			} catch (\PDOException $ex) {
+				self::assertFalse(true);
+			}
+
+			try {
+				$stmt = $db->prepare('INSERT INTO User (ID, Username, Email) VALUES (:id, :username, :email)');
+				$stmt->bindValue(':id', 1, \PDO::PARAM_INT);
+				$stmt->bindValue(':username', 'AndyM84', \PDO::PARAM_INT);
+				$stmt->bindValue(':email', 'andrew.male@grokspark.com', \PDO::PARAM_STR);
+				$stmt->execute();
+			} catch (\PDOException $ex) {
+				self::assertEquals('SQLSTATE[23000]: Integrity constraint violation: 19 UNIQUE constraint failed: User.ID', $ex->getMessage());
+			}
+
+			return;
+		}
+	}

--- a/Utilities/BaseDbClass.php
+++ b/Utilities/BaseDbClass.php
@@ -1,0 +1,88 @@
+<?php
+
+	namespace Stoic\Utilities;
+
+	use Stoic\Log\Logger;
+
+	/**
+	 * Abstract base class that ensures the availability
+	 * of a PDO instance, Logger instance, and some basic
+	 * meta information on the called class.
+	 *
+	 * @package Stoic\Pdo
+	 * @version 1.0.0
+	 */
+	abstract class BaseDbClass {
+		/**
+		 * Fully qualified current class name.
+		 *
+		 * @var string
+		 */
+		protected $className = null;
+		/**
+		 * Internal PDO instance.
+		 *
+		 * @var \PDO
+		 */
+		protected $db = null;
+		/**
+		 * Internal Logger instance.
+		 *
+		 * @var \Stoic\Log\Logger
+		 */
+		protected $log = null;
+		/**
+		 * Short (non-qualified) current class
+		 * name.
+		 *
+		 * @var string
+		 */
+		protected $shortClassName = null;
+
+
+		/**
+		 * Instantiates a new BaseDbClass object with the required dependencies.
+		 *
+		 * @param \PDO $db PDO instance for use by object.
+		 * @param Logger $log Logger instance for use by object, defaults to new instance.
+		 */
+		final public function __construct(\PDO $db, Logger $log = null) {
+			$this->db = $db;
+			$this->log = $log ?? new Logger();
+			$this->className = get_called_class();
+			$this->shortClassName = (new \ReflectionClass($this))->getShortName();
+
+			$this->__initialize();
+
+			return;
+		}
+
+		/**
+		 * Optional method to initialize an object after the constructor has been
+		 * called.
+		 *
+		 * @return void
+		 */
+		protected function __initialize() {
+			return;
+		}
+
+		/**
+		 * Method to perform common wrapping of PDO code blocks in \PDOException
+		 * catch and prefix errors with the given message.  Returns any value(s)
+		 * returned by the callable code block.
+		 *
+		 * @param callable $callable Block of code to execute and guard against PDOExceptions.
+		 * @param string $errorPrefix String prefix to use when logging exception messages.
+		 * @return mixed
+		 */
+		protected function tryPdoExcept(callable $callable, string $errorPrefix) {
+			try {
+				return $callable();
+			} catch (\PDOException $ex) {
+				$this->log->error("{$errorPrefix}: {ERROR}", ['ERROR' => $ex]);
+			}
+
+			return null;
+		}
+	}

--- a/Utilities/BaseDbModel.php
+++ b/Utilities/BaseDbModel.php
@@ -1,0 +1,964 @@
+<?php
+
+	namespace Stoic\Utilities;
+
+	use Stoic\Log\Logger;
+	use Stoic\Utilities\EnumBase;
+	use Stoic\Utilities\ReturnHelper;
+
+	/**
+	 * Exception thrown if a property isn't found during
+	 * calls to BaseDbModel::fromArray().
+	 *
+	 * @package Stoic\Pdo
+	 * @version 1.0.0
+	 */
+	class ClassPropertyNotFoundException extends \Exception { }
+
+	/**
+	 * Represents a database field type.
+	 *
+	 * @package Stoic\Pdo
+	 * @version 1.0.0
+	 */
+	class BaseDbTypes extends EnumBase {
+		const INTEGER = 0;
+		const STRING = 1;
+		const BOOLEAN = 2;
+		const NILL = 3;
+		const DATETIME = 4;
+
+
+		/**
+		 * Retreives the PDO parameter type to be used with a
+		 * column of this type.
+		 *
+		 * @return integer|null
+		 */
+		public function getDbType() {
+			if ($this->getValue() === null) {
+				return null;
+			}
+
+			switch ($this->getValue()) {
+				case self::INTEGER:
+					return \PDO::PARAM_INT;
+				case self::STRING:
+				case self::DATETIME:
+					return \PDO::PARAM_STR;
+				case self::BOOLEAN:
+					return \PDO::PARAM_BOOL;
+				case self::NILL:
+					return \PDO::PARAM_NULL;
+			}
+
+			// @codeCoverageIgnoreStart
+			return null;
+			// @codeCoverageIgnoreEnd
+		}
+	}
+
+	/**
+	 * Represents the different types of queries that can
+	 * be generated for a BaseDbModel.
+	 *
+	 * @package Stoic\Pdo
+	 * @version 1.0.0
+	 */
+	class BaseDbQueryTypes extends EnumBase {
+		const INVALID = 0;
+		const DELETE = 1;
+		const INSERT = 2;
+		const SELECT = 3;
+		const UPDATE = 4;
+	}
+
+	/**
+	 * Represents a single database field
+	 * in a BaseDbModel.
+	 *
+	 * @package Stoic\Pdo
+	 * @version 1.0.0
+	 */
+	class BaseDbField {
+		/**
+		 * Whether or not this field can be null
+		 * when used in a query.
+		 *
+		 * @var boolean
+		 */
+		public $allowsNulls;
+		/**
+		 * Name of the database column for
+		 * this field.
+		 *
+		 * @var StringHelper
+		 */
+		public $column;
+		/**
+		 * Whether or not the field receives an
+		 * AUTO_INCREMENT value upon insertion.
+		 *
+		 * @var boolean
+		 */
+		public $autoIncrement;
+		/**
+		 * The database type for this field.
+		 *
+		 * @var BaseDbTypes
+		 */
+		public $type;
+		/**
+		 * Whether or not this field is the
+		 * key for the table.
+		 *
+		 * @var boolean
+		 */
+		public $isKey;
+		/**
+		 * Whether or not to use this field
+		 * during row creation.
+		 *
+		 * @var boolean
+		 */
+		public $shouldInsert;
+		/**
+		 * Whether or not to use this field
+		 * during row updates.
+		 *
+		 * @var boolean
+		 */
+		public $shouldUpdate;
+
+
+		/**
+		 * Instantiates a BaseDbField object with the
+		 * given values.
+		 *
+		 * @param string $column Name of the database column.
+		 * @param integer $type Type of the database column.
+		 * @param boolean $isKey Whether or not this is part of the table key.
+		 * @param boolean $shouldInsert Whether or not this should be used during row creation.
+		 * @param boolean $shouldUpdate Whether or not this should be used during row updates.
+		 * @param boolean $allowsNulls Whether or not this should be allowed to be null.
+		 * @param boolean $autoIncrement Whether or not this receives an AUTO_INCREMENT value after insertion.
+		 */
+		public function __construct($column, $type, $isKey, $shouldInsert, $shouldUpdate, $allowsNulls = false, $autoIncrement = false) {
+			$this->allowsNulls = $allowsNulls;
+			$this->column = new StringHelper($column);
+			$this->type = new BaseDbTypes($type);
+			$this->isKey = $isKey;
+			$this->shouldInsert = $shouldInsert;
+			$this->shouldUpdate = $shouldUpdate;
+			$this->autoIncrement = $autoIncrement;
+
+			if ($this->column->isEmptyOrNullOrWhitespace()) {
+				throw new \InvalidArgumentException("Cannot create a BaseDbField object with no column name");
+			}
+
+			if ($this->type->getValue() === null) {
+				throw new \InvalidArgumentException("Cannot create a BaseDbField object with an invalid BaseDbTypes value");
+			}
+
+			return;
+		}
+	}
+
+	/**
+	 * Abstract base class that provides simplistic ORM
+	 * functionality without much fuss/overhead.
+	 *
+	 * @package Stoic\Pdo
+	 * @version 1.0.0
+	 */
+	abstract class BaseDbModel extends BaseDbClass {
+		/**
+		 * Currently called class name.
+		 *
+		 * @var string
+		 */
+		protected $className = null;
+		/**
+		 * Internal PDO instance.
+		 *
+		 * @var \PDO
+		 */
+		protected $db = null;
+		/**
+		 * Optional collection of BaseDbField
+		 * objects representing object
+		 * properties.
+		 *
+		 * @var BaseDbField[]
+		 */
+		protected $dbFields = [];
+		/**
+		 * Name of the database table this class
+		 * will query against.
+		 *
+		 * @var StringHelper
+		 */
+		protected $dbTable = null;
+		/**
+		 * Internal \Stoic\Log\Logger instance.
+		 *
+		 * @var Logger
+		 */
+		protected $log = null;
+		/**
+		 * Current called class name without
+		 * namespaces.
+		 *
+		 * @var string
+		 */
+		protected $shortClassName;
+
+
+		/**
+		 * Cached collection of object properties.
+		 *
+		 * @var array
+		 */
+		protected static $properties = [];
+
+
+		/**
+		 * Array-based instantiation of base class objects.
+		 *
+		 * @param array $source Array to use as source for object properties.
+		 * @param \PDO $db PDO connection resource for use by object.
+		 * @param Logger $log Optional Logger instance for use by object, new instance created if not supplied.
+		 * @param array $exclusions Optional array of properties to exclude when comparing property counts.
+		 * @throws \InvalidArgumentException Thrown if provided with empty or incorrectly sized source array.
+		 * @throws ClassPropertyNotFoundException Thrown if a source array element doesn't find a suitable class property.
+		 * @return object
+		 */
+		public static function fromArray(array $source, \PDO $db, Logger $log = null, array $exclusions = null) {
+			$className = get_called_class();
+
+			if (count($source) < 1) {
+				throw new \InvalidArgumentException("Cannot populate {$className} from empty source array");
+			}
+
+			static::persistClassProperties();
+			$baseVars = static::$properties['BaseDbModel'];
+
+			if ($exclusions !== null) {
+				foreach (array_values($exclusions) as $ex) {
+					$baseVars[$ex] = true;
+				}
+			}
+
+			if ((count(static::$properties[$className]) - count($baseVars)) != count($source)) {
+				throw new \InvalidArgumentException("Cannot populate {$className} from array, variable count mismatch (class: " . (count(static::$properties[$className]) - count($baseVars)) . ", source: " . count($source) . ")");
+			}
+
+			$ret = new $className($db, $log);
+
+			foreach ($source as $key => $val) {
+				$keyFound = false;
+				$loweredKey = strtolower($key);
+
+				foreach (array_keys(static::$properties[$className]) as $prop) {
+					if (strtolower($prop) == $loweredKey) {
+						$keyFound = true;
+
+						if (array_key_exists($prop, $ret->dbFields)) {
+							$ret->setPropertyDbValue($prop, $ret->dbFields[$prop], $val);
+						} else {
+							$ret->{$prop} = $val;
+						}
+
+						break;
+					}
+				}
+
+				if ($keyFound === false) {
+					throw new ClassPropertyNotFoundException("Couldn't find match for {$key} index while populating {$className}");
+				}
+			}
+
+			return $ret;
+		}
+
+		/**
+		 * Static method to ensure class properties have been setup in the
+		 * cache.
+		 *
+		 * @return void
+		 */
+		protected static function persistClassProperties() {
+			if (array_key_exists('BaseDbModel', static::$properties) === false) {
+				static::$properties['BaseDbModel'] = get_class_vars(get_class());
+			}
+
+			$className = get_called_class();
+
+			if (array_key_exists($className, static::$properties) === false) {
+				static::$properties[$className] = get_class_vars($className);
+			}
+
+			return;
+		}
+
+
+		/**
+		 * Optional method to determine if a 'create'
+		 * action can proceed.
+		 *
+		 * @return boolean
+		 */
+		protected function __canCreate() {
+			return true;
+		}
+
+		/**
+		 * Optional method to determine if a 'delete'
+		 * action can proceed.
+		 *
+		 * @return boolean
+		 */
+		protected function __canDelete() {
+			return true;
+		}
+
+		/**
+		 * Optional method to determine if a 'read'
+		 * action can proceed.
+		 *
+		 * @return boolean
+		 */
+		protected function __canRead() {
+			return true;
+		}
+
+		/**
+		 * Optional method to determine if an 'update'
+		 * action can proceed.
+		 *
+		 * @return boolean
+		 */
+		protected function __canUpdate() {
+			return true;
+		}
+
+		/**
+		 * Retrieves the value of a set property.
+		 *
+		 * @param string $name Name of the property to attempt retrieving.
+		 * @return mixed
+		 */
+		public function __get($name) {
+			if (array_key_exists($name, $this->dbFields) !== false) {
+				if ($this->dbFields[$name]->type->is(BaseDbTypes::STRING) && $this->{$name} instanceof StringHelper) {
+					return $this->{$name}->data();
+				} else if ($this->dbFields[$name]->type->is(BaseDbTypes::DATETIME) && $this->{$name} instanceof \DateTimeInterface) {
+					return $this->{$name}->format('Y-m-d H:i:s');
+				} else {
+					return $this->{$name};
+				}
+			} else {
+				$this->log->warning("Attempted to retrieve non-existent field: {field}", array('field' => $name));
+			}
+
+			return null;
+		}
+
+		/**
+		 * Optional method to initialize an object
+		 * after the constructor has finished.
+		 *
+		 * @return void
+		 */
+		final protected function __initialize() {
+			static::persistClassProperties();
+
+			if ($this->db instanceof PdoHelper) {
+				
+			}
+
+			$this->__setupModel();
+
+			return;
+		}
+
+		/**
+		 * Sets the value of an existing property.
+		 *
+		 * @param string $name Name of property to attempt setting.
+		 * @param mixed $value Value to set property to if it exists.
+		 * @return void
+		 */
+		public function __set($name, $value) {
+			if (array_key_exists($name, $this->dbFields) !== false) {
+				$field = $this->dbFields[$name];
+
+				if ($value === null && $field->allowsNulls) {
+					// @codeCoverageIgnoreStart
+					$this->{$name} = $value;
+					// @codeCoverageIgnoreEnd
+				} else if ($field->type->is(BaseDbTypes::STRING)) {
+					$this->{$name} = new StringHelper($value);
+				} else if ($field->type->is(BaseDbTypes::DATETIME) && !($value instanceof \DateTimeInterface)) {
+					$this->{$name} = new \DateTimeImmutable($value);
+				} else if ($this->{$name} instanceof EnumBase && !($value instanceof EnumBase)) {
+					$enumClass = get_class($this->{$name});
+					$this->{$name} = new $enumClass($value);
+				} else {
+					$this->{$name} = $value;
+				}
+			} else {
+				$this->log->warning("Attempted to set non-existent field: {field} => {value}", array('field' => $name, 'value' => $value));
+			}
+
+			return;
+		}
+
+		protected function __setupModel() {
+			return;
+		}
+
+		/**
+		 * Attempts to create a new object in
+		 * the database.
+		 *
+		 * @return ReturnHelper
+		 */
+		public function create() {
+			$ret = new ReturnHelper();
+			$ret->makeBad();
+
+			if (!$this->canProceed('create', $this->__canCreate(), $ret)) {
+				return $ret;
+			}
+
+			$autoIncField = null;
+			$insertFields = array();
+			$insertColumns = array();
+
+			foreach ($this->dbFields as $property => $field) {
+				if ($field->shouldInsert) {
+					$insertFields[] = $this->getPropertyDbValue($property, $field);
+					$insertColumns[$field->column->data()] = ":{$property}";
+				}
+
+				if ($field->autoIncrement === true) {
+					$autoIncField = $property;
+				}
+			}
+
+			if (count($insertFields) < 1) {
+				$ret->addMessage("Can't perform generated 'create', no fields available for insertion");
+				$this->logErrors($ret);
+
+				return $ret;
+			}
+
+			try {
+				$sql = "INSERT INTO `{$this->dbTable}` (`" . implode('`,`', array_keys($insertColumns)) . "`) VALUES (" . implode(', ', array_values($insertColumns)) . ")";
+				$stmt = $this->db->prepare($sql);
+				$paramOutput = [];
+
+				foreach (array_values($insertFields) as $field) {
+					$stmt->bindValue($field[0], $field[1], $field[2]);
+					$paramOutput[$field[0]] = $field[1];
+				}
+
+				$this->log->info("Attempting to create " . $this->className . " automatically with...\n\tQuery: {SQL}\n\tParams: {PARAMS}", array('SQL' => $sql, 'PARAMS' => $paramOutput));
+
+				$stmt->execute();
+
+				if ($autoIncField !== null) {
+					$this->log->info("Attempting to set autoInc field: {$autoIncField}");
+					$this->{$autoIncField} = $this->db->lastInsertId();
+				}
+
+				$ret->makeGood();
+				$this->log->info("Successfully created " . $this->className);
+			// @codeCoverageIgnoreStart
+			} catch (\PDOException $ex) {
+				$this->log->error("Failed to create " . $this->className . ": {ERROR}", array('ERROR' => $ex));
+				$ret->addMessage("Failed to create {$this->className}:  {$ex->getMessage()}");
+			}
+			// @codeCoverageIgnoreEnd
+
+			$this->logErrors($ret);
+
+			return $ret;
+		}
+
+		/**
+		 * Determines if a response from a proceed-check method
+		 * should stop an automatic query from being executed.
+		 *
+		 * If a ReturnHelper is provided, all messages will be
+		 * placed in error logs in the result of a failed check.
+		 *
+		 * @param string $operation Name of operation that is about to be performed.
+		 * @param mixed $value Value from proceed-check, likely boolean or ReturnHelper.
+		 * @param null|ReturnHelper $ret Optional ReturnHelper to append message onto.
+		 * @return boolean
+		 */
+		protected function canProceed($operation, $value, ReturnHelper &$ret = null) {
+			if ($value instanceof ReturnHelper) {
+				if ($value->isGood()) {
+					return true;
+				}
+
+				if ($value->hasMessages()) {
+					foreach (array_values($value->getMessages()) as $msg) {
+						$this->log->error($msg);
+
+						if ($ret !== null) {
+							$ret->addMessage($msg);
+						}
+					}
+				}
+
+				return false;
+			}
+
+			if ($value === false) {
+				$this->log->error("Unable to '{$operation}', {$this->className} returned false");
+
+				return false;
+			}
+
+			if (count($this->dbFields) < 1) {
+				$this->log->error("Can't perform generated '{$operation}' on {$this->className} without registered fields");
+
+				if ($ret !== null) {
+					$ret->addMessage("Can't perform generated '{$operation}' on {$this->className} without registered fields");
+				}
+
+				return false;
+			}
+
+			return true;
+		}
+
+		/**
+		 * Attempts to delete an object in the
+		 * database.
+		 *
+		 * @return ReturnHelper
+		 */
+		public function delete() {
+			$ret = new ReturnHelper();
+			$ret->makeBad();
+
+			if (!$this->canProceed('delete', $this->__canDelete(), $ret)) {
+				return $ret;
+			}
+
+			$primaries = array();
+			$primaryStrings = array();
+
+			foreach ($this->dbFields as $property => $field) {
+				if ($field->isKey) {
+					$primaries[] = $this->getPropertyDbValue($property, $field);
+					$primaryStrings[] = "`{$field->column}` = :{$property}";
+				}
+			}
+
+			if (count($primaries) < 1) {
+				$ret->addMessage("Can't perform generated 'delete', no fields available for query");
+				$this->logErrors($ret);
+
+				return $ret;
+			}
+
+			try {
+				$sql = "DELETE FROM `{$this->dbTable}` WHERE " . implode(' AND ', array_values($primaryStrings));
+				$stmt = $this->db->prepare($sql);
+				$paramOutput = [];
+
+				foreach (array_values($primaries) as $field) {
+					$stmt->bindValue($field[0], $field[1], $field[2]);
+					$paramOutput[$field[0]] = $field[1];
+				}
+
+				$this->log->info("Attempting to run generated 'delete'..\n\tQuery: {SQL}\n\tParams: {PARAMS}", array('SQL' => $sql, 'PARAMS' => $paramOutput));
+
+				$stmt->execute();
+				$ret->makeGood();
+				$this->log->info("Successfully deleted {$this->className}");
+			// @codeCoverageIgnoreStart
+			} catch (\PDOException $ex) {
+				$this->log->error("Failed to delete {$this->className} with error: {ERROR}", array('ERROR' => $ex));
+				$ret->addMessage("Failed to delete {$this->className}: {$ex->getMessage()}");
+			}
+			// @codeCoverageIgnoreEnd
+
+			$this->logErrors($ret);
+
+			return $ret;
+		}
+
+		/**
+		 * Attempts to generate a query string to be used elsewhere.  Optional parameter
+		 * only affects SELECT queries.
+		 *
+		 * @param integer|BaseDbQueryTypes $queryType Type of query to generate with class meta information.
+		 * @param boolean $includeSelectPrimaries Determines if SELECT queries should also include the WHERE section of the query, defaults to true.
+		 * @return string
+		 */
+		public function generateClassQuery($queryType, bool $includeSelectPrimaries = true) : string {
+			$ret = '';
+			$queryType = EnumBase::tryGetEnum($queryType, BaseDbQueryTypes::class);
+
+			$insertFields = [];
+			$insertColumns = [];
+			$selectColumns = [];
+			$updateColumns = [];
+			$primaryStrings = [];
+
+			foreach ($this->dbFields as $property => $field) {
+				if ($field->shouldInsert) {
+					$insertFields[] = $this->getPropertyDbValue($property, $field);
+					$insertColumns[$field->column->data()] = ":{$property}";
+				}
+
+				if ($field->isKey) {
+					$primaryStrings[] = "`{$field->column}` = :{$property}";
+				}
+
+				if ($field->shouldUpdate) {
+					$updateColumns[] = "`{$field->column}` = :{$property}";
+				}
+
+				$selectColumns[] = $field->column;
+			}
+
+			switch ($queryType->getValue()) {
+				case BaseDbQueryTypes::DELETE:
+					$ret = "DELETE FROM `{$this->dbTable}` WHERE " . implode(' AND ', array_values($primaryStrings));
+
+					break;
+				case BaseDbQueryTypes::INSERT:
+					$ret = "INSERT INTO `{$this->dbTable}` (`" . implode('`, `', array_keys($insertColumns)) . "`) VALUES (" . implode(', ', array_values($insertColumns)) . ")";
+
+					break;
+				case BaseDbQueryTypes::SELECT:
+					$ret = "SELECT `" . implode('`, `', array_values($selectColumns)) . "` FROM `{$this->dbTable}`";
+
+					if ($includeSelectPrimaries) {
+						$ret .= " WHERE " . implode(' AND ', array_values($primaryStrings));
+					}
+
+					break;
+				case BaseDbQueryTypes::UPDATE:
+					$ret = "UPDATE `{$this->dbTable}` SET " . implode(', ', array_values($updateColumns)) . " WHERE " .implode(' AND ', array_values($primaryStrings));
+
+					break;
+			}
+
+			return $ret;
+		}
+
+		/**
+		 * Returns the fully qualified class name of the current class.
+		 *
+		 * @return string
+		 */
+		public function getClassName() {
+			return $this->className;
+		}
+
+		/**
+		 * Returns the currently set collection of database
+		 * columns/fields.
+		 *
+		 * @return BaseDbField[]
+		 */
+		public function getDbColumns() {
+			return $this->dbFields;
+		}
+
+		/**
+		 * Attempts to retrieve the DB value for
+		 * the given property.
+		 *
+		 * @param string $property Name of property on class to retrieve.
+		 * @param BaseDbField $field Field information to use when formatting value.
+		 * @return array
+		 */
+		protected function getPropertyDbValue($property, BaseDbField $field) {
+			$ret = array(":{$property}", '', $field->type->getDbType());
+
+			if ($field->allowsNulls && $this->{$property} === null) {
+				// @codeCoverageIgnoreStart
+				$ret[1] = null;
+				$ret[2] = \PDO::PARAM_NULL;
+				// @codeCoverageIgnoreEnd
+			} else if ($this->{$property} instanceof \DateTimeInterface) {
+				$ret[1] = $this->{$property}->format('Y-m-d H:i:s');
+			} else if ($field->type->is(BaseDbTypes::STRING) && $this->{$property} instanceof StringHelper) {
+				$ret[1] = $this->{$property}->data();
+			} else if ($field->type->is(BaseDbTypes::BOOLEAN)) {
+				$ret[1] = ($this->{$property}) ? 1 : 0;
+			} else if ($field->type->is(BaseDbTypes::STRING) && $this->{$property} instanceof EnumBase) {
+				// @codeCoverageIgnoreStart
+				$ret[1] = $this->{$property}->getName();
+				// @codeCoverageIgnoreEnd
+			} else if ($field->type->is(BaseDbTypes::INTEGER) && $this->{$property} instanceof EnumBase) {
+				$ret[1] = $this->{$property}->getValue();
+			} else {
+				$ret[1] = $this->{$property};
+			}
+
+			return $ret;
+		}
+
+		/**
+		 * Returns the shortened class name of the current class.
+		 *
+		 * @return string
+		 */
+		public function getShortClassName() {
+			return $this->shortClassName;
+		}
+
+		/**
+		 * Logs any errors from the given ReturnHelper.
+		 *
+		 * @param ReturnHelper $ret ReturnHelper to scan for errors.
+		 * @return void
+		 */
+		protected function logErrors(ReturnHelper $ret) {
+			if ($ret->isBad() && $ret->hasMessages()) {
+				foreach (array_values($ret->getMessages()) as $message) {
+					$this->log->error($message);
+				}
+			}
+
+			return;
+		}
+
+		/**
+		 * Attempts to read an object from the
+		 * database.
+		 *
+		 * @return ReturnHelper
+		 */
+		public function read() {
+			$ret = new ReturnHelper();
+			$ret->makeBad();
+
+			if (!$this->canProceed('read', $this->__canRead(), $ret)) {
+				return $ret;
+			}
+
+			$columns = array();
+			$primaries = array();
+			$primaryStrings = array();
+
+			foreach ($this->dbFields as $property => $field) {
+				if ($field->isKey) {
+					$primaries[] = $this->getPropertyDbValue($property, $field);
+					$primaryStrings[] = "`{$field->column}` = :{$property}";
+				}
+
+				$columns[] = $field->column;
+			}
+
+			if (count($primaries) < 1) {
+				$ret->addMessage("Can't perform generated 'read', no fields available for query");
+				$this->logErrors($ret);
+
+				return $ret;
+			}
+
+			try {
+				$sql = "SELECT `" . implode('`, `', array_values($columns)) . "` FROM `{$this->dbTable}` WHERE " . implode(' AND ', array_values($primaryStrings));
+				$stmt = $this->db->prepare($sql);
+				$paramOutput = [];
+
+				foreach (array_values($primaries) as $field) {
+					$stmt->bindValue($field[0], $field[1], $field[2]);
+					$paramOutput[$field[0]] = $field[1];
+				}
+
+				$this->log->info("Attempting to 'read' {$this->className}..\n\tQuery: {SQL}\n\tParams: {PARAMS}", array('SQL' => $sql, 'PARAMS' => $paramOutput));
+
+				$stmt->execute();
+
+				if ($stmt->rowCount() > 0) {
+					$row = $stmt->fetch();
+
+					foreach ($this->dbFields as $property => $field) {
+						$this->setPropertyDbValue($property, $field, $row[$field->column->data()]);
+					}
+
+					$ret->makeGood();
+				} else {
+					$ret->addMessage("No results found for generated 'read' query, read aborted");
+				}
+			// @codeCoverageIgnoreStart
+			} catch (\PDOException $ex) {
+				$this->log->error("Failed to read {$this->className} object with error: {ERROR}", array('ERROR' => $ex));
+				$ret->addMessage("Failed to read {$this->className}: {$ex->getMessage()}");
+			}
+			// @codeCoverageIgnoreEnd
+
+			$this->logErrors($ret);
+
+			return $ret;
+		}
+
+		/**
+		 * Attempts to set a database field in the current
+		 * object.
+		 *
+		 * @param string $property Name of the class property this field corresponds to.
+		 * @param string $column Name of the database column.
+		 * @param integer $type Type of the database column.
+		 * @param boolean $isKey Whether or not this is part of the table key.
+		 * @param boolean $shouldInsert Whether or not this should be used during row creation.
+		 * @param boolean $shouldUpdate Whether or not this should be used during row updates.
+		 * @param boolean $allowsNulls Whether or not this should be allowed to be null.
+		 * @param boolean $autoIncrement Whether or not this receives an AUTO_INCREMENT value after insertion.
+		 * @throws \InvalidArgumentException Thrown if the property already has an assigned database field.
+		 * @return void
+		 */
+		protected function setColumn($property, $column, $type, $isKey, $shouldInsert, $shouldUpdate, $allowsNulls = false, $autoIncrement = false) {
+			if (array_key_exists($property, $this->dbFields) !== false) {
+				throw new \InvalidArgumentException("Cannot overwrite a field that has already been set");
+			}
+
+			$this->dbFields[$property] = new BaseDbField($column, $type, $isKey, $shouldInsert, $shouldUpdate, $allowsNulls, $autoIncrement);
+
+			return;
+		}
+
+		/**
+		 * Sets the value of a class property.
+		 *
+		 * @param string $property Name of property on class to set.
+		 * @param BaseDbField $field Field information to use when formatting value.
+		 * @param mixed $value Value to set class property to.
+		 * @return void
+		 */
+		protected function setPropertyDbValue($property, BaseDbField $field, $value) {
+			if ($field->type->is(BaseDbTypes::DATETIME) && $value !== null) {
+				$this->{$property} = new \DateTimeImmutable($value, new \DateTimeZone('UTC'));
+			} else if ($field->type->is(BaseDbTypes::BOOLEAN)) {
+				$this->{$property} = ($value) ? true : false;
+			} else if ($field->type->is(BaseDbTypes::STRING) && $this->{$property} instanceof EnumBase) {
+				$enumClass = get_class($this->{$property});
+				$this->{$property} = $enumClass::fromString($value);
+			} else if ($field->type->is(BaseDbTypes::INTEGER) && $this->{$property} instanceof EnumBase) {
+				$enumClass = get_class($this->{$property});
+				$this->{$property} = new $enumClass(intval($value));
+			} else {
+				$this->{$property} = $value;
+			}
+
+			return;
+		}
+
+		/**
+		 * Sets the database table name for this
+		 * object.
+		 *
+		 * @param string $name Value of table name.
+		 * @return void
+		 */
+		protected function setTableName($name) {
+			$this->dbTable = new StringHelper($name);
+
+			return;
+		}
+
+		/**
+		 * Returns all registered db fields with their values as
+		 * an array.
+		 *
+		 * @return array
+		 */
+		public function toArray() {
+			$ret = [];
+
+			if (count($this->dbFields) > 0) {
+				foreach (array_keys($this->dbFields) as $prop) {
+					$ret[$prop] = $this->{$prop};
+				}
+			}
+
+			return $ret;
+		}
+
+		/**
+		 * Attempts to update an object in the
+		 * database.
+		 *
+		 * @return ReturnHelper
+		 */
+		public function update() {
+			$ret = new ReturnHelper();
+			$ret->makeBad();
+
+			if (!$this->canProceed('update', $this->__canUpdate(), $ret)) {
+				$this->log->error("Not allowed to update.");
+
+				return $ret;
+			}
+
+			$primaries = array();
+			$primaryStrings = array();
+			$updateColumns = array();
+			$updateColumnStrings = array();
+
+			foreach ($this->dbFields as $property => $field) {
+				$colProp = ":{$property}";
+
+				if ($field->isKey) {
+					$primaries[] = $this->getPropertyDbValue($property, $field);
+					$primaryStrings[] = "`{$field->column}` = {$colProp}";
+				}
+
+				if ($field->shouldUpdate) {
+					$updateColumns[] = $this->getPropertyDbValue($property, $field);
+					$updateColumnStrings[] = "`{$field->column}` = {$colProp}";
+				}
+			}
+
+			if (count($primaries) < 1) {
+				$ret->addMessage("Can't perform generated 'update' on class without primary fields");
+				$this->logErrors($ret);
+
+				return $ret;
+			}
+
+			try {
+				$sql = "UPDATE `{$this->dbTable}` SET " . implode(', ', array_values($updateColumnStrings)) . " WHERE " .implode(' AND ', array_values($primaryStrings));
+				$stmt = $this->db->prepare($sql);
+				$paramOutput = [];
+
+				foreach (array_values($primaries) as $field) {
+					$stmt->bindValue($field[0], $field[1], $field[2]);
+					$paramOutput[$field[0]] = $field[1];
+				}
+
+				foreach (array_values($updateColumns) as $field) {
+					$stmt->bindValue($field[0], $field[1], $field[2]);
+					$paramOutput[$field[0]] = $field[1];
+				}
+
+				$this->log->info("Attempting to 'update' {$this->className}..\n\tQuery: {SQL}\n\tParams: {PARAMS}", array('SQL' => $sql, 'PARAMS' => $paramOutput));
+
+				$stmt->execute();
+				$ret->makeGood();
+				$this->log->info("Successfully updated {$this->className}");
+			// @codeCoverageIgnoreStart
+			} catch (\PDOException $ex) {
+				$this->log->error("Failed to update {$this->className} with error: {ERROR}", array('ERROR' => $ex));
+				$ret->addMessage("Failed to update {$this->className} with error: {$ex->getMessage()}");
+			}
+			// @codeCoverageIgnoreEnd
+
+			$this->logErrors($ret);
+
+			return $ret;
+		}
+	}

--- a/Utilities/PdoHelper.php
+++ b/Utilities/PdoHelper.php
@@ -1,0 +1,804 @@
+<?php
+
+	namespace Stoic\Utilities;
+
+	use Stoic\Utilities\EnumBase;
+
+	/**
+	 * Enumerated PDO driver types, used for meta information.
+	 *
+	 * @package Stoic\Pdo
+	 * @version 1.0.0
+	 */
+	class PdoDrivers extends EnumBase {
+		const PDO_4D       = 1;
+		const PDO_CUBRID   = 2;
+		const PDO_FIREBIRD = 3;
+		const PDO_FREETDS  = 4;
+		const PDO_IBM      = 5;
+		const PDO_INFORMIX = 6;
+		const PDO_MSSQL    = 7;
+		const PDO_MYSQL    = 8;
+		const PDO_ODBC     = 9;
+		const PDO_ORACLE   = 10;
+		const PDO_PGSQL    = 11;
+		const PDO_SQLITE   = 12;
+		const PDO_SQLSRV   = 13;
+		const PDO_SYBASE   = 14;
+	}
+
+	/**
+	 * Data for an argument used with a stored
+	 * query.
+	 *
+	 * @package Stoic\Pdo
+	 * @version 1.0.0
+	 */
+	class PdoStoredArgument {
+		/**
+		 * String value of argument name.
+		 *
+		 * @var string
+		 */
+		public $name = null;
+		/**
+		 * PDO parameter type for argument.
+		 *
+		 * @var integer
+		 */
+		public $type = -1;
+
+
+		/**
+		 * Instantiates a new PdoStoredArgument object.
+		 *
+		 * @param string $name String value of argument name.
+		 * @param int $type PDO parameter type for argument.
+		 */
+		public function __construct(string $name, int $type) {
+			$this->name = $name;
+			$this->type = $type;
+
+			return;
+		}
+	}
+
+	/**
+	 * Meta information for a query intended for re-use.
+	 *
+	 * @package Stoic\Pdo
+	 * @version 1.0.0
+	 */
+	class PdoStoredQuery {
+		/**
+		 * String identifier of query.
+		 *
+		 * @var string
+		 */
+		public $key = null;
+		/**
+		 * Query string stored for later use.
+		 *
+		 * @var string
+		 */
+		public $query = null;
+		/**
+		 * Arguments the query string will require
+		 * when used.
+		 *
+		 * @var PdoStoredArgument[]
+		 */
+		public $arguments = [];
+
+
+		/**
+		 * Instantiates a new PdoStoredQuery object.
+		 *
+		 * @param string $key String identifier of query.
+		 * @param string $query Query string being recorded.
+		 * @param PdoStoredArgument[] $arguments Optional array of arguments to use with query.
+		 */
+		public function __construct(string $key, string $query, array $arguments = null) {
+			$this->key = $key;
+			$this->query = $query;
+
+			if ($arguments !== null) {
+				foreach ($arguments as $name => $type) {
+					$this->arguments[$name] = new PdoStoredArgument($name, $type);
+				}
+			}
+
+			return;
+		}
+	}
+
+	/**
+	 * Query meta class for tracking queries run through the
+	 * PdoHelper.
+	 *
+	 * @package Stoic\Pdo
+	 * @version 1.0.0
+	 */
+	class PdoQuery implements \JsonSerializable {
+		/**
+		 * Collection of arguments provided to query, if available.
+		 *
+		 * @var array
+		 */
+		public $arguments = [];
+		/**
+		 * Query string.
+		 *
+		 * @var string
+		 */
+		public $query = null;
+
+
+		/**
+		 * Instantiates a new PdoQuery object.
+		 *
+		 * @param string $query The query string that is being recorded.
+		 * @param array $arguments Optional array of arguments used with query in format ['name', 'value', 'type'].
+		 */
+		public function __construct(string $query, array $arguments = null) {
+			$this->query = $query;
+
+			if ($arguments !== null) {
+				$this->arguments = $arguments;
+			}
+
+			return;
+		}
+
+		/**
+		 * Provides serialized data structure for json_encode.
+		 *
+		 * @return array
+		 */
+		public function jsonSerialize() {
+			return [
+				'query' => $this->query,
+				'arguments' => $this->arguments
+			];
+		}
+	}
+
+	/**
+	 * Error meta class for useful additional information
+	 * on queries run through the PdoHelper.
+	 *
+	 * @package Stoic\Pdo
+	 * @version 1.0.0
+	 */
+	class PdoError implements \JsonSerializable {
+		/**
+		 * The PDOException that was thrown at the time of the error.
+		 *
+		 * @var \PDOException
+		 */
+		public $exception = null;
+		/**
+		 * The query that caused the error, if available.
+		 *
+		 * @var PdoQuery
+		 */
+		public $query = null;
+
+
+		/**
+		 * Instantiates a new PdoError object.
+		 *
+		 * @param \PDOException $exception Exception that is being recorded.
+		 * @param PdoQuery $query Query object that caused the thrown exception.
+		 */
+		public function __construct(\PDOException $exception, PdoQuery $query) {
+			$this->exception = $exception;
+			$this->query = $query;
+
+			return;
+		}
+
+		/**
+		 * Provides serialized data structure for json_encode.
+		 *
+		 * @return array
+		 */
+		public function jsonSerialize() {
+			return [
+				'message' => $this->exception->getMessage(),
+				'stackTrace' => $this->exception->getTraceAsString(),
+				'query' => $this->query
+			];
+		}
+	}
+
+	/**
+	 * Class that wraps around a PDO instance to provide
+	 * useful common operations and meta information.
+	 *
+	 * @package Stoic\Pdo
+	 * @version 1.0.0
+	 */
+	class PdoHelper extends \PDO {
+		/**
+		 * Whether or not the class has an active connection.
+		 *
+		 * @var boolean
+		 */
+		protected $active = false;
+		/**
+		 * The DSN that was provided at initialization.
+		 *
+		 * @var string
+		 */
+		public $dsn = null;
+		/**
+		 * Currently configured driver as specified by the
+		 * connection string.
+		 *
+		 * @var string
+		 */
+		protected $driver = null;
+		/**
+		 * Collection of errors thrown by connection.
+		 *
+		 * @var PdoError[]
+		 */
+		protected $errors = [];
+		/**
+		 * The array of options provided at initialization, if available.
+		 *
+		 * @var array
+		 */
+		public $options = [];
+		/**
+		 * Collection of query strings that have been run through
+		 * the helper.
+		 *
+		 * @var PdoQuery[]
+		 */
+		protected $queries = [];
+		/**
+		 * Number of queries that have been run through the helper.
+		 *
+		 * @var integer
+		 */
+		protected $queryCount = 0;
+
+
+		/**
+		 * Static lookup of drivers by DSN prefix.
+		 *
+		 * @var array
+		 */
+		protected static $driverLookup = [
+			'4D'       => [PdoDrivers::PDO_4D,       '4d'],
+			'cubrid'   => [PdoDrivers::PDO_CUBRID,   'cubrid'],
+			'firebird' => [PdoDrivers::PDO_FIREBIRD, 'firebird'],
+			'dblib'    => [PdoDrivers::PDO_FREETDS,  'freetds'],
+			'ibm'      => [PdoDrivers::PDO_IBM,      'ibm'],
+			'informix' => [PdoDrivers::PDO_INFORMIX, 'informix'],
+			'mssql'    => [PdoDrivers::PDO_MSSQL,    'mssql'],
+			'mysql'    => [PdoDrivers::PDO_MYSQL,    'mysql'],
+			'odbc'     => [PdoDrivers::PDO_ODBC,     'odbc'],
+			'oci'      => [PdoDrivers::PDO_ORACLE,   'oracle'],
+			'pgsql'    => [PdoDrivers::PDO_PGSQL,    'postgresql'],
+			'sqlite'   => [PdoDrivers::PDO_SQLITE,   'sqlite'],
+			'sqlsrv'   => [PdoDrivers::PDO_SQLSRV,   'azure'],
+			'sybase'   => [PdoDrivers::PDO_SYBASE,   'sybase']
+		];
+		/**
+		 * Static collection of stored queries, grouped by
+		 * driver and key.
+		 *
+		 * @var array
+		 */
+		protected static $storedQueries = [];
+
+
+		/**
+		 * Attempts to store a driver-specific query for later recall via the
+		 * provided key.
+		 *
+		 * @param integer|string $driver Driver identifier (integer or string).
+		 * @param string $key String identifier for the query.
+		 * @param string $query Query string that should be stored by the given key.
+		 * @param array $arguments Optional array of arguments the query will require in formation 'name' => 'type'.
+		 * @return boolean
+		 */
+		public static function storeQuery($driver, string $key, string $query, array $arguments = null) : bool {
+			$ret = true;
+			$foundDriver = false;
+			$driverTestZero = true;
+			$query = new PdoStoredQuery($key, $query, $arguments);
+
+			if (is_string($driver)) {
+				$driverTestZero = false;
+				$driver = strtolower($driver);
+			}
+
+			foreach (array_values(static::$driverLookup) as $drvr) {
+				if (($driverTestZero && $drvr[0] === $driver) || (!$driverTestZero && $drvr[1] === $driver)) {
+					$foundDriver = true;
+
+					if ($driverTestZero) {
+						$driver = $drvr[1];
+					}
+
+					break;
+				}
+			}
+
+			if (!$foundDriver) {
+				return false;
+			}
+
+			if (array_key_exists($driver, static::$storedQueries) === false) {
+				static::$storedQueries[$driver] = [$key => $query];
+			} else if (array_key_exists($key, static::$storedQueries[$driver]) !== false) {
+				$ret = false;
+			} else {
+				static::$storedQueries[$driver][$key] = $query;
+			}
+
+			return $ret;
+		}
+
+		/**
+		 * Attempts to store one or more driver-specific queries for later recall
+		 * via the provided key(s).
+		 *
+		 * @param integer|string $driver Driver identifier (integer or string).
+		 * @param array $queries Array of query information to store, in format ['key', 'query', [':argName' => 'argType']].
+		 * @return void
+		 */
+		public static function storeQueries($driver, array $queries = null) {
+			if ($queries !== null) {
+				foreach (array_values($queries) as $query) {
+					static::storeQuery($driver, $query[0], $query[1], $query[2]);
+				}
+			}
+
+			return;
+		}
+
+
+		/**
+		 * Instantiates a new PdoHelper object.
+		 *
+		 * @param string $dsn Data source name (DSN) containing the information to connect to the database.
+		 * @param string $username Username for the DSN string, optional depending on PDO driver.
+		 * @param string $password Password for the DSN string, optional depending on PDO driver.
+		 * @param array $options A key=>value array of driver-specific connection options.
+		 */
+		public function __construct(string $dsn, string $username = null, string $password = null, array $options = null) {
+			try {
+				$args = [$dsn];
+
+				// @codeCoverageIgnoreStart
+				if ($username !== null) {
+					$args[] = $username;
+
+					if ($password !== null) {
+						$args[] = $password;
+
+						if ($options !== null) {
+							$args[] = $options;
+						}
+					}
+				}
+				// @codeCoverageIgnoreEnd
+
+				call_user_func_array(['parent', '__construct'], $args);
+
+				$this->dsn = $dsn;
+				$this->options = $options ?? [];
+
+				foreach (array_keys(static::$driverLookup) as $prefix) {
+					if (strtolower(substr($dsn, 0, (strlen($prefix) + 1))) == strtolower($prefix) . ':') {
+						$this->driver = static::$driverLookup[$prefix][1];
+
+						break;
+					}
+				}
+
+				if ($this->driver === null) {
+					// @codeCoverageIgnoreStart
+					throw new \PDOException("Invalid driver provided");
+					// @codeCoverageIgnoreEnd
+				}
+
+				$this->active = true;
+			// @codeCoverageIgnoreStart
+			} catch (\PDOException $ex) {
+				$this->active = false;
+				$this->errors[] = new PdoError($ex, new PdoQuery('connect'));
+			}
+			// @codeCoverageIgnoreEnd
+
+			return;
+		}
+
+		/**
+		 * Initiates a transaction.
+		 *
+		 * @return boolean
+		 */
+		public function beginTransaction() : bool {
+			return $this->tryActiveCommand(function () {
+				return parent::beginTransaction();
+			}, false);
+		}
+
+		/**
+		 * Commits a transaction.
+		 *
+		 * @return boolean
+		 */
+		public function commit() : bool {
+			return $this->tryActiveCommand(function () {
+				return parent::commit();
+			}, false);
+		}
+
+		/**
+		 * Fetch the SQLSTATE associated with the last operation on
+		 * the database handle.
+		 *
+		 * @return string
+		 */
+		public function errorCode() : string {
+			return $this->tryActiveCommand(function () {
+				return parent::errorCode();
+			}, '');
+		}
+
+		/**
+		 * Fetch extended error information associated with the last
+		 * operation on the database handle.
+		 *
+		 * @return array
+		 */
+		public function errorInfo() : array {
+			return $this->tryActiveCommand(function () {
+				return parent::errorInfo();
+			}, []);
+		}
+
+		/**
+		 * Execute a SQL statement and return the number of affected
+		 * rows.
+		 *
+		 * @param string $statement The SQL statement to prepare and execute
+		 * @return integer
+		 */
+		public function exec($query) {
+			return $this->tryActiveCommand(function () use ($query) {
+				$ret = 0;
+
+				try {
+					$ret = parent::exec($query);
+					$this->storeQueryRecord($query);
+				} catch (\PDOException $ex) {
+					$this->errors[] = new PdoError($ex, new PdoQuery($query));
+
+					throw $ex;
+				}
+
+				return $ret;
+			}, 0);
+		}
+
+		/**
+		 * Execute a stored SQL statement and return the number of
+		 * affected rows.
+		 *
+		 * @param string $key The key identifying the stored query.
+		 * @return integer
+		 */
+		public function execStored(string $key) : int {
+			return $this->tryActiveCommand(function () use ($key) {
+				if (array_key_exists($key, static::$storedQueries[$this->driver]) === false || count(static::$storedQueries[$this->driver][$key]->arguments) > 0) {
+					return 0;
+				}
+
+				return $this->exec(static::$storedQueries[$this->driver][$key]->query);
+			}, 0);
+		}
+
+		/**
+		 * Retrieve a database connection attribute.
+		 *
+		 * @param integer $attribute One of the \PDO::ATTR_* constants.
+		 * @return mixed
+		 */
+		public function getAttribute($attribute) {
+			return $this->tryActiveCommand(function () use ($attribute) {
+				return parent::getAttribute($attribute);
+			}, null);
+		}
+
+		/**
+		 * Retrieves all errors that have been recorded by
+		 * the helper instance.
+		 *
+		 * @return PdoError[]
+		 */
+		public function getErrors() {
+			return $this->errors;
+		}
+
+		/**
+		 * Retrieves all queries that have been recorded by
+		 * the helper instance.
+		 *
+		 * @return PdoQuery[]
+		 */
+		public function getQueries() {
+			return $this->queries;
+		}
+
+		/**
+		 * Retrieves the number of queries that have been
+		 * run by the helper instance.
+		 *
+		 * @return integer
+		 */
+		public function getQueryCount() {
+			return $this->queryCount;
+		}
+
+		/**
+		 * Checks if inside a transaction.
+		 *
+		 * @return boolean
+		 */
+		public function inTransaction() : bool {
+			return $this->tryActiveCommand(function () {
+				return parent::inTransaction();
+			}, false);
+		}
+
+		/**
+		 * Returns whether or not the helper has an active
+		 * database connection.
+		 *
+		 * @return boolean
+		 */
+		public function isActive() : bool {
+			return $this->active;
+		}
+
+		/**
+		 * Returns the ID of the last inserted row or sequence value.
+		 *
+		 * @param string $seqname Name of the sequence object from which the ID should be returned.
+		 * @return mixed
+		 */
+		public function lastInsertId($seqname = NULL) {
+			return $this->tryActiveCommand(function () use ($seqname) {
+				return parent::lastInsertId($seqname);
+			}, '');
+		}
+
+		/**
+		 * Prepares a statement for execution and returns a statement object.
+		 *
+		 * @param string $statement This must be a valid SQL statement template for the target database server.
+		 * @param array $options Holds one or more key=>value pairs to set attribute values for the PDOStatement object that this method returns.
+		 * @return \PDOStatement
+		 */
+		public function prepare($statement, $options = NULL) {
+			return $this->tryActiveCommand(function () use ($statement, $options) {
+				$ret = null;
+
+				try {
+					if ($options !== null) {
+						// @codeCoverageIgnoreStart
+						$ret = parent::prepare($statement, $options);
+						// @codeCoverageIgnoreEnd
+					} else {
+						$ret = parent::prepare($statement);
+					}
+
+					$this->storeQueryRecord($statement);
+				// @codeCoverageIgnoreStart
+				} catch (\PDOException $ex) {
+					$this->errors[] = new PdoError($ex, new PdoQuery($statement));
+
+					throw $ex;
+				}
+				// @codeCoverageIgnoreEnd
+
+				return $ret;
+			}, null);
+		}
+
+		/**
+		 * Prepares a stored statement for execution and returns a statement object.
+		 *
+		 * @param string $key Identifier for stored query.
+		 * @param array $arguments Argument values in name=>value format to include with statement template.
+		 * @param array $options Holds one or more key=>value pairs to set attribute values for the PDOStatement object that this method returns.
+		 * @return \PDOStatement
+		 */
+		public function prepareStored(string $key, array $arguments = array(), array $options = null) {
+			return $this->tryActiveCommand(function () use ($key, $arguments, $options) {
+				if (array_key_exists($key, static::$storedQueries[$this->driver]) === false || count(static::$storedQueries[$this->driver][$key]->arguments) !== count($arguments)) {
+					return null;
+				}
+
+				$args = [];
+				$stmt = null;
+				$statement = static::$storedQueries[$this->driver][$key]->query;
+
+				if (count($arguments) > 0) {
+					foreach ($arguments as $aKey => $value) {
+						if (array_key_exists($aKey, static::$storedQueries[$this->driver][$key]->arguments) === false) {
+							return null;
+						}
+
+						$args[] = ["{$aKey}", $value, static::$storedQueries[$this->driver][$key]->arguments[$aKey]->type];
+					}
+				}
+
+				try {
+					if ($options !== null) {
+						// @codeCoverageIgnoreStart
+						$stmt = parent::prepare($statement, $options);
+						// @codeCoverageIgnoreEnd
+					} else {
+						$stmt = parent::prepare($statement);
+					}
+
+					foreach (array_values($args) as $argSet) {
+						$stmt->bindValue($argSet[0], $argSet[1], $argSet[2]);
+					}
+
+					$this->storeQueryRecord($statement, $args);
+				// @codeCoverageIgnoreStart
+				} catch (\PDOException $ex) {
+					$this->errors[] = new PdoError($ex, new PdoQuery($statement, $args));
+
+					throw $ex;
+				}
+				// @codeCoverageIgnoreEnd
+
+				return $stmt;
+			}, null);
+		}
+
+		/**
+		 * Executes a SQL statement, returning a result set as a PDOStatement object.
+		 *
+		 * @param string $statement The SQL statement to prepare and execute.
+		 * @return \PDOStatement
+		 */
+		public function query(string $statement) {
+			return $this->tryActiveCommand(function () use ($statement) {
+				$ret = null;
+
+				try {
+					$ret = parent::query($statement);
+					$this->storeQueryRecord($statement);
+				// @codeCoverageIgnoreStart
+				} catch (\PDOException $ex) {
+					$this->errors[] = new PdoError($ex, new PdoQuery($statement));
+
+					throw $ex;
+				}
+				// @codeCoverageIgnoreEnd
+
+				return $ret;
+			}, null);
+		}
+
+		/**
+		 * Executes a stored SQL statement, returning a result set as a PDOStatement
+		 * object.
+		 *
+		 * @param string $key Identifier for stored query.
+		 * @return \PDOStatement
+		 */
+		public function queryStored(string $key) {
+			return $this->tryActiveCommand(function () use ($key) {
+				if (array_key_exists($key, static::$storedQueries[$this->driver]) === false || count(static::$storedQueries[$this->driver][$key]->arguments) > 0) {
+					return null;
+				}
+
+				return $this->query(static::$storedQueries[$this->driver][$key]->query);
+			}, null);
+		}
+
+		/**
+		 * Quotes a string for use in a query.
+		 *
+		 * @param string $string The string to be quoted.
+		 * @param integer $paramtype Provides a data type hint for drivers that have alternate quoting styles.
+		 * @return string
+		 */
+		public function quote($string, $paramtype = NULL) {
+			return $this->tryActiveCommand(function () use ($string, $paramtype) {
+				if ($paramtype > -1) {
+					return parent::quote($string, $paramtype);
+				}
+
+				return parent::quote($string);
+			}, '');
+		}
+		
+		/**
+		 * Rolls back a transaction.
+		 *
+		 * @return boolean
+		 */
+		public function rollback() : bool {
+			return $this->tryActiveCommand(function () {
+				return parent::rollBack();
+			}, false);
+		}
+
+		/**
+		 * Set an attribute.
+		 *
+		 * @param integer $attribute PDO::ATTR_* constant to set on handler.
+		 * @param mixed $value Value to set for the selected attribute.
+		 * @return boolean
+		 */
+		public function setAttribute($attribute, $value) {
+			return $this->tryActiveCommand(function () use ($attribute, $value) {
+				return parent::setAttribute($attribute, $value);
+			}, false);
+		}
+
+		/**
+		 * Sets multiple attributes in format attribute=>value.
+		 *
+		 * @param array $attributes Array of attributes and their values to set.
+		 * @return void
+		 */
+		public function setAttributes(array $attributes = null) {
+			if (!$this->active || $attributes === null) {
+				return;
+			}
+
+			foreach ($attributes as $attrib => $value) {
+				$this->setAttribute($attrib, $value);
+			}
+
+			return;
+		}
+
+		/**
+		 * Stores a query that has been executed, it's arguments if available,
+		 * and increments the query counter.
+		 *
+		 * @param string $query The SQL statement that was executed.
+		 * @param array $arguments Possible collection of argument passed to statement.
+		 * @return void
+		 */
+		protected function storeQueryRecord($query, array $arguments = null) {
+			$this->queryCount++;
+			$this->queries[] = new PdoQuery($query, $arguments);
+
+			return;
+		}
+
+		/**
+		 * Helper method to guard statements against being called when there
+		 * is no active database handle.
+		 *
+		 * @param callable $command The code to execute if the handle is active.
+		 * @param mixed $default Return value if the handle is inactive.
+		 * @return mixed
+		 */
+		protected function tryActiveCommand(callable $command, $default = null) {
+			if ($this->active) {
+				return $command();
+			}
+
+			// @codeCoverageIgnoreStart
+			return $default;
+			// @codeCoverageIgnoreEnd
+		}
+	}

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
 		"stoic/io": "dev-master"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^7"
+		"phpunit/phpunit": "^7",
+		"jimbojsb/pseudo": "0.4"
 	}
 }


### PR DESCRIPTION
Provides code and tests (~100% coverage) for three utilities:

* `PdoHelper` - A quick wrapper over the `PDO` class which provides some additional tracking and meta information, as well as the ability to store queries for later use
* `BaseDbClass` - A simple abstract class that requires a `PDO` object, `Stoic\Log\Logger` object, and provides some basic meta information about the class
* `BaseDbModel` - An abstract class (with helper classes) that provides very basic ORM capabilities in a very configurable and override-able manner

Would like to merge this to master so I can begin working with this while I work on documentation.