### PR TITLE
1.0.9 Improvements

### DIFF
--- a/Pdo/BaseDbModel.php
+++ b/Pdo/BaseDbModel.php
@@ -457,7 +457,7 @@
 					$paramOutput[$field[0]] = $field[1];
 				}
 
-				$this->log->info("Attempting to create " . $this->className . " automatically with...\n\tQuery: {SQL}\n\tParams: {PARAMS}", array('SQL' => $sql, 'PARAMS' => $paramOutput));
+				$this->log->info("Attempting to create " . $this->className . " automatically with...\n\tQuery: {SQL}\n\tParams: {PARAMS}", array('SQL' => $sql, 'PARAMS' => json_encode($paramOutput)));
 
 				$stmt->execute();
 
@@ -571,7 +571,7 @@
 					$paramOutput[$field[0]] = $field[1];
 				}
 
-				$this->log->info("Attempting to run generated 'delete'..\n\tQuery: {SQL}\n\tParams: {PARAMS}", array('SQL' => $sql, 'PARAMS' => $paramOutput));
+				$this->log->info("Attempting to run generated 'delete'..\n\tQuery: {SQL}\n\tParams: {PARAMS}", array('SQL' => $sql, 'PARAMS' => json_encode($paramOutput)));
 
 				$stmt->execute();
 				$ret->makeGood();
@@ -881,7 +881,7 @@
 					$paramOutput[$field[0]] = $field[1];
 				}
 
-				$this->log->info("Attempting to 'read' {$this->className}..\n\tQuery: {SQL}\n\tParams: {PARAMS}", array('SQL' => $sql, 'PARAMS' => $paramOutput));
+				$this->log->info("Attempting to 'read' {$this->className}..\n\tQuery: {SQL}\n\tParams: {PARAMS}", array('SQL' => $sql, 'PARAMS' => json_encode($paramOutput)));
 
 				$cmp = $stmt->execute();
 
@@ -1073,7 +1073,7 @@
 					$paramOutput[$field[0]] = $field[1];
 				}
 
-				$this->log->info("Attempting to 'update' {$this->className}..\n\tQuery: {SQL}\n\tParams: {PARAMS}", array('SQL' => $sql, 'PARAMS' => $paramOutput));
+				$this->log->info("Attempting to 'update' {$this->className}..\n\tQuery: {SQL}\n\tParams: {PARAMS}", array('SQL' => $sql, 'PARAMS' => json_encode($paramOutput)));
 
 				$stmt->execute();
 				$ret->makeGood();

--- a/Pdo/BaseDbModel.php
+++ b/Pdo/BaseDbModel.php
@@ -817,6 +817,9 @@
 		 * @return void
 		 */
 		protected function logErrors(ReturnHelper $ret) : void {
+			$trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+			$this->log->error("BaseDbModel error log originating from {FILE}:{LINE}", ['FILE' => $trace[0]['file'], 'LINE' => $trace[0]['line']]);
+
 			if ($ret->isBad() && $ret->hasMessages()) {
 				foreach (array_values($ret->getMessages()) as $message) {
 					$this->log->error($message);

--- a/Pdo/BaseDbModel.php
+++ b/Pdo/BaseDbModel.php
@@ -593,10 +593,10 @@
 		 * only affects SELECT queries.
 		 *
 		 * @param integer|BaseDbQueryTypes $queryType Type of query to generate with class meta information.
-		 * @param boolean $includeSelectPrimaries Determines if SELECT queries should also include the WHERE section of the query, defaults to true.
+		 * @param boolean $includePrimaryWheres Determines if queries should also include the WHERE section with primary keys included, defaults to true.
 		 * @return string
 		 */
-		public function generateClassQuery($queryType, bool $includeSelectPrimaries = true) : string {
+		public function generateClassQuery($queryType, bool $includePrimaryWheres = true) : string {
 			$ret = '';
 			$queryType = EnumBase::tryGetEnum($queryType, BaseDbQueryTypes::class);
 
@@ -623,7 +623,7 @@
 
 			switch ($queryType->getValue()) {
 				case BaseDbQueryTypes::DELETE:
-					$ret = "DELETE FROM {$this->dbTable} WHERE " . implode(' AND ', array_values($primaryStrings));
+					$ret = "DELETE FROM {$this->dbTable}";
 
 					break;
 				case BaseDbQueryTypes::INSERT:
@@ -633,15 +633,15 @@
 				case BaseDbQueryTypes::SELECT:
 					$ret = "SELECT " . $this->getDbColumnPrefix() . implode($this->getDbColumnSuffix() . ', ' . $this->getDbColumnPrefix(), array_values($selectColumns)) . $this->getDbColumnSuffix() . " FROM {$this->dbTable}";
 
-					if ($includeSelectPrimaries) {
-						$ret .= " WHERE " . implode(' AND ', array_values($primaryStrings));
-					}
-
 					break;
 				case BaseDbQueryTypes::UPDATE:
-					$ret = "UPDATE {$this->dbTable} SET " . implode(', ', array_values($updateColumns)) . " WHERE " .implode(' AND ', array_values($primaryStrings));
+					$ret = "UPDATE {$this->dbTable} SET " . implode(', ', array_values($updateColumns));
 
 					break;
+			}
+
+			if (!$queryType->is(BaseDbQueryTypes::INSERT) && $includePrimaryWheres) {
+				$ret .= " WHERE " .implode(' AND ', array_values($primaryStrings));
 			}
 
 			return $ret;

--- a/Pdo/PdoHelper.php
+++ b/Pdo/PdoHelper.php
@@ -253,6 +253,12 @@
 		 */
 		protected $errors = [];
 		/**
+		 * Optional internal PDO instance, for when the object is wrapping a pre-existing resource.
+		 *
+		 * @var null|\PDO
+		 */
+		protected $instance = null;
+		/**
 		 * The array of options provided at initialization, if available.
 		 *
 		 * @var array
@@ -377,8 +383,20 @@
 		 * @param string $username Username for the DSN string, optional depending on PDO driver.
 		 * @param string $password Password for the DSN string, optional depending on PDO driver.
 		 * @param array $options A key=>value array of driver-specific connection options.
+		 * @param \PDO $instance Optional PDO instance to wrap around instead of initializing internally.
 		 */
-		public function __construct(string $dsn, string $username = null, string $password = null, array $options = null) {
+		public function __construct(string $dsn, string $username = null, string $password = null, array $options = null, \PDO $instance = null) {
+			if ($instance !== null) {
+				$this->instance = $instance;
+
+				$driver           = $this->instance->getAttribute(\PDO::ATTR_DRIVER_NAME);
+				$this->driverKey  = static::$driverLookup[$driver][1];
+				$this->driver     = new PdoDrivers(static::$driverLookup[$driver][0]);
+				
+
+				return;
+			}
+
 			try {
 				$args = [$dsn];
 
@@ -403,7 +421,7 @@
 
 				foreach (array_keys(static::$driverLookup) as $prefix) {
 					if (strtolower(substr($dsn, 0, (strlen($prefix) + 1))) == strtolower($prefix) . ':') {
-						$this->driverName = static::$driverLookup[$prefix][1];
+						$this->driverKey = static::$driverLookup[$prefix][1];
 						$this->driver = new PdoDrivers(static::$driverLookup[$prefix][0]);
 
 						break;
@@ -434,6 +452,10 @@
 		 */
 		public function beginTransaction() : bool {
 			return $this->tryActiveCommand(function () {
+				if ($this->instance !== null) {
+					return $this->instance->beginTransaction();
+				}
+
 				return parent::beginTransaction();
 			}, false);
 		}
@@ -445,6 +467,10 @@
 		 */
 		public function commit() : bool {
 			return $this->tryActiveCommand(function () {
+				if ($this->instance !== null) {
+					return $this->instance->commit();
+				}
+
 				return parent::commit();
 			}, false);
 		}
@@ -457,6 +483,10 @@
 		 */
 		public function errorCode() : string {
 			return $this->tryActiveCommand(function () {
+				if ($this->instance !== null) {
+					return $this->instance->errorCode();
+				}
+
 				return parent::errorCode();
 			}, '');
 		}
@@ -469,6 +499,10 @@
 		 */
 		public function errorInfo() {
 			return $this->tryActiveCommand(function () {
+				if ($this->instance !== null) {
+					return $this->instance->errorInfo();
+				}
+
 				return parent::errorInfo();
 			}, []);
 		}
@@ -485,7 +519,7 @@
 				$ret = 0;
 
 				try {
-					$ret = parent::exec($query);
+					$ret = ($this->instance !== null) ? $this->instance->exec($query) : parent::exec($query);
 					$this->storeQueryRecord($query);
 				} catch (\PDOException $ex) {
 					$this->errors[] = new PdoError($ex, new PdoQuery($query));
@@ -506,11 +540,15 @@
 		 */
 		public function execStored(string $key) : int {
 			return $this->tryActiveCommand(function () use ($key) {
-				if (array_key_exists($key, static::$storedQueries[$this->driverName]) === false || count(static::$storedQueries[$this->driverName][$key]->arguments) > 0) {
+				if (array_key_exists($key, static::$storedQueries[$this->driverKey]) === false || count(static::$storedQueries[$this->driverKey][$key]->arguments) > 0) {
 					return 0;
 				}
 
-				return $this->exec(static::$storedQueries[$this->driverName][$key]->query);
+				if ($this->instance !== null) {
+					return $this->instance->exec(static::$storedQueries[$this->driverKey][$key]->query);
+				}
+
+				return $this->exec(static::$storedQueries[$this->driverKey][$key]->query);
 			}, 0);
 		}
 
@@ -522,6 +560,10 @@
 		 */
 		public function getAttribute($attribute) {
 			return $this->tryActiveCommand(function () use ($attribute) {
+				if ($this->instance !== null) {
+					return $this->instance->getAttribute($attribute);
+				}
+
 				return parent::getAttribute($attribute);
 			}, null);
 		}
@@ -641,21 +683,21 @@
 		 */
 		public function prepareStored(string $key, array $arguments = [], array $options = null) {
 			return $this->tryActiveCommand(function () use ($key, $arguments, $options) {
-				if (array_key_exists($key, static::$storedQueries[$this->driverName]) === false || count(static::$storedQueries[$this->driverName][$key]->arguments) !== count($arguments)) {
+				if (array_key_exists($key, static::$storedQueries[$this->driverKey]) === false || count(static::$storedQueries[$this->driverKey][$key]->arguments) !== count($arguments)) {
 					return null;
 				}
 
 				$args = [];
 				$stmt = null;
-				$statement = static::$storedQueries[$this->driverName][$key]->query;
+				$statement = static::$storedQueries[$this->driverKey][$key]->query;
 
 				if (count($arguments) > 0) {
 					foreach ($arguments as $aKey => $value) {
-						if (array_key_exists($aKey, static::$storedQueries[$this->driverName][$key]->arguments) === false) {
+						if (array_key_exists($aKey, static::$storedQueries[$this->driverKey][$key]->arguments) === false) {
 							return null;
 						}
 
-						$args[] = ["{$aKey}", $value, static::$storedQueries[$this->driverName][$key]->arguments[$aKey]->type];
+						$args[] = ["{$aKey}", $value, static::$storedQueries[$this->driverKey][$key]->arguments[$aKey]->type];
 					}
 				}
 
@@ -719,11 +761,11 @@
 		 */
 		public function queryStored(string $key) {
 			return $this->tryActiveCommand(function () use ($key) {
-				if (array_key_exists($key, static::$storedQueries[$this->driverName]) === false || count(static::$storedQueries[$this->driverName][$key]->arguments) > 0) {
+				if (array_key_exists($key, static::$storedQueries[$this->driverKey]) === false || count(static::$storedQueries[$this->driverKey][$key]->arguments) > 0) {
 					return null;
 				}
 
-				return $this->query(static::$storedQueries[$this->driverName][$key]->query);
+				return $this->query(static::$storedQueries[$this->driverKey][$key]->query);
 			}, null);
 		}
 

--- a/Pdo/PdoHelper.php
+++ b/Pdo/PdoHelper.php
@@ -392,7 +392,7 @@
 				$driver           = $this->instance->getAttribute(\PDO::ATTR_DRIVER_NAME);
 				$this->driverKey  = static::$driverLookup[$driver][1];
 				$this->driver     = new PdoDrivers(static::$driverLookup[$driver][0]);
-				
+				$this->active     = true;
 
 				return;
 			}

--- a/Pdo/StoicDbClass.php
+++ b/Pdo/StoicDbClass.php
@@ -32,7 +32,7 @@
 			parent::__construct($db, $log);
 
 			if (!($db instanceof PdoHelper)) {
-				throw new \InvalidArgumentException("StoicDbClass and derived classes require a PdoHelper");
+				$this->db = new PdoHelper('', null, null, null, $db);
 			}
 
 			return;

--- a/Pdo/StoicDbModel.php
+++ b/Pdo/StoicDbModel.php
@@ -30,7 +30,7 @@
 			parent::__initialize();
 
 			if (!($this->db instanceof PdoHelper)) {
-				throw new \InvalidArgumentException("StoicDbModel and derived classes require a PdoHelper");
+				$this->db = new PdoHelper('', null, null, null, $this->db);
 			}
 
 			return;

--- a/Tests/BaseDbModelTest.php
+++ b/Tests/BaseDbModelTest.php
@@ -453,9 +453,9 @@
 			self::assertEquals('SELECT ID, Name FROM Role WHERE ID = :id', $role->generateClassQuery(BaseDbQueryTypes::SELECT));
 			self::assertEquals('SELECT ID, Name FROM Role', $role->generateClassQuery(BaseDbQueryTypes::SELECT, false));
 			self::assertEquals('UPDATE Role SET Name = :name WHERE ID = :id', $role->generateClassQuery(BaseDbQueryTypes::UPDATE));
-			self::assertEquals('UPDATE Role SET Name = :name WHERE ID = :id', $role->generateClassQuery(BaseDbQueryTypes::UPDATE, false));
+			self::assertEquals('UPDATE Role SET Name = :name', $role->generateClassQuery(BaseDbQueryTypes::UPDATE, false));
 			self::assertEquals('DELETE FROM Role WHERE ID = :id', $role->generateClassQuery(BaseDbQueryTypes::DELETE));
-			self::assertEquals('DELETE FROM Role WHERE ID = :id', $role->generateClassQuery(BaseDbQueryTypes::DELETE, false));
+			self::assertEquals('DELETE FROM Role', $role->generateClassQuery(BaseDbQueryTypes::DELETE, false));
 
 			return;
 		}

--- a/Tests/PdoHelperTest.php
+++ b/Tests/PdoHelperTest.php
@@ -79,6 +79,10 @@
 			self::assertTrue((new PdoHelper('sqlite::memory:'))->isActive());
 			self::assertTrue((new PdoHelper('sqlite::memory:'))->getDriver()->getValue() === PdoDrivers::PDO_SQLITE);
 
+			$pdo = new \PDO('sqlite::memory:');
+			self::assertTrue((new PdoHelper('', null, null, null, $pdo))->isActive());
+			self::assertTrue((new PdoHelper('', null, null, null, $pdo))->getDriver()->getValue() === PdoDrivers::PDO_SQLITE);
+
 			return;
 		}
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
 		"php": ">=7.4",
 		"stoic/stoic": "^1.0",
 		"stoic/io": "^1.0",
-		"ext-pdo": "*"
+		"ext-pdo": "*",
+		"ext-json": "*"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
 	"require": {
 		"php": ">=7.4",
 		"stoic/stoic": "^1.0",
-		"stoic/io": "^1.0"
+		"stoic/io": "^1.0",
+		"ext-pdo": "*"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9",


### PR DESCRIPTION
Made the following changes/additions:

* [#5] Added output of top of `debug_backtrace` stack for `BaseDbModel` error reports
* Cleaned query info log output to use `json_encode` instead of simple `print_r()` call w/ newlines
* [#6] Modified `PdoHelper` and `StoicDbClass`/`StoicDbModel` classes to allow for `PDO` wrap instead of exceptions
* [#7] Added ability to exclude PRIMARY keys from DELETE and UPDATE queries, in addition to previous use with SELECT's

All tests pass locally, with the caveat being that you must fix `jimbojsb/pseudo` method signatures to match PHP 8+ PDO signatures in order for the tests to run.